### PR TITLE
Disable REUSE check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,12 +33,3 @@ jobs:
         uses: actions/checkout@v2
       - name: Lint YAML files
         uses: ibiqlik/action-yamllint@v3
-
-  REUSE:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Clone the repository
-        uses: actions/checkout@v2
-      - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v1

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ SPDX-FileCopyrightText: 2021 HH Partners, Attorneys-at-law Ltd <doubleopen@hhpar
 SPDX-License-Identifier: CC0-1.0
 -->
 
-[![REUSE status](https://api.reuse.software/badge/github.com/doubleopen-project/policy-configuration)](https://api.reuse.software/info/github.com/doubleopen-project/policy-configuration)
-
 # Double Open Policy Configuration
 
 This repository is used to maintain the license classification (license-classifications.yml) created by Double Open.


### PR DESCRIPTION
Storing the custom license texts in the repository makes REUSE
compliance somewhat complicated. Disable the CI check for REUSE
compliance at least temporarily.
