### PR TITLE
Jyrki 1

### DIFF
--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -546,6 +546,15 @@ categorizations:
       - "property:AutoConf-or-other-exception"
 
   # https://spdx.org/licenses/GPL-2.0-or-later.html
+  # https://spdx.org/licenses/Autoconf-exception-generic.html
+  - id: "GPL-2.0-or-later WITH Autoconf-exception-generic"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-2.0-or-later.html
   # https://spdx.org/licenses/Classpath-exception-2.0.html
   - id: "GPL-2.0-or-later WITH Classpath-exception-2.0"
     categories:
@@ -2065,6 +2074,15 @@ categorizations:
       - "property:distribute-source-code"
       - "property:AutoConf-or-other-exception"
 
+  # https://spdx.org/licenses/GPL-1.0-or-later.html
+  # https://spdx.org/licenses/Autoconf-exception-generic.html
+  - id: "GPL-1.0-or-later WITH Autoconf-exception-generic"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
   # https://spdx.org/licenses/GPL-2.0-or-later.html
   # https://spdx.org/licenses/Linux-syscall-note.html
   - id: "GPL-2.0-or-later WITH Linux-syscall-note"
@@ -2143,6 +2161,17 @@ categorizations:
   # https://spdx.org/licenses/GPL-3.0-or-later.html
   # http://git.openembedded.org/openembedded-core/tree/meta/files/common-licenses/GPL-2.0-with-autoconf-exception
   - id: "GPL-3.0-or-later-with-Autoconf-macro-exception"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-3.0-or-later.html
+  # https://scancode-licensedb.aboutcode.org/autoconf-macro-exception.html
+  - id: "GPL-3.0-or-later WITH LicenseRef-scancode-autoconf-macro-exception"
     categories:
       - "copyleft-strong"
       - "property:include-in-notice-file"
@@ -2576,6 +2605,28 @@ categorizations:
       - "property:AutoConf-or-other-exception"
 
   # https://spdx.org/licenses/GPL-3.0-or-later.html
+  # https://spdx.org/licenses/Autoconf-exception-generic.html
+  - id: "GPL-3.0-or-later WITH Autoconf-exception-generic"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-3.0-or-later.html
+  # https://spdx.org/licenses/Autoconf-exception-2.0.html
+  - id: "GPL-3.0-or-later WITH Autoconf-exception-2.0"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-3.0-or-later.html
   # https://spdx.org/licenses/Autoconf-exception-3.0.html
   - id: "GPL-3.0-or-later WITH Autoconf-exception-3.0"
     categories:
@@ -2589,6 +2640,28 @@ categorizations:
   # https://spdx.org/licenses/GPL-3.0-or-later.html
   # https://spdx.org/licenses/Libtool-exception.html
   - id: "GPL-3.0-or-later WITH Libtool-exception"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-3.0-or-later.html
+  # https://scancode-licensedb.aboutcode.org/autoconf-simple-exception.html
+  - id: "GPL-3.0-or-later WITH LicenseRef-scancode-autoconf-simple-exception"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-3.0-or-later.html
+  # https://scancode-licensedb.aboutcode.org/tex-exception.html
+  - id: "GPL-3.0-or-later WITH LicenseRef-scancode-tex-exception"
     categories:
       - "copyleft-strong"
       - "property:include-in-notice-file"

--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -1460,6 +1460,12 @@ categorizations:
       - "permissive"
       - "property:include-in-notice-file"
 
+  # https://spdx.org/licenses/FSFULLRWD.html
+  - id: "FSFULLRWD"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
   # https://scancode-licensedb.aboutcode.org/fsf-unlimited-no-warranty.html
   - id: "LicenseRef-FSF-Unlimited-No-Warranty"
     categories:

--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -311,6 +311,12 @@ categorizations:
       - "permissive"
       - "property:include-in-notice-file"
 
+# https://spdx.org/licenses/BSD-4.3TAHOE.html
+  - id: "BSD-4.3TAHOE"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
   - id: "LicenseRef-scancode-bsd-original-uc-1986"
     categories:
       - "permissive"

--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -1195,6 +1195,12 @@ categorizations:
       - "permissive"
       - "property:include-in-notice-file"
 
+  # https://spdx.org/licenses/snprintf.html
+  - id: "snprintf"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
   # https://github.com/nexB/scancode-toolkit/blob/ded56e9120f5fdfb9a1a0309130bb4305a66aacb/src/licensedcode/data/licenses/philippe-de-muyter.LICENSE
   - id: "LicenseRef-scancode-philippe-de-muyter"
     categories:

--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -545,6 +545,15 @@ categorizations:
       - "property:distribute-source-code"
       - "property:AutoConf-or-other-exception"
 
+  # https://spdx.org/licenses/GPL-2.0-only.html
+  # https://scancode-licensedb.aboutcode.org/mysql-linking-exception-2018.html
+  - id: "GPL-2.0-only WITH LicenseRef-scancode-mysql-linking-exception-2018"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
   # https://spdx.org/licenses/GPL-2.0-or-later.html
   # https://spdx.org/licenses/Autoconf-exception-generic.html
   - id: "GPL-2.0-or-later WITH Autoconf-exception-generic"
@@ -2690,6 +2699,15 @@ categorizations:
       - "property:patent-clause"
       - "property:AutoConf-or-other-exception"
 
+  # https://scancode-licensedb.aboutcode.org/bison-exception-2.0.html
+  - id: "LicenseRef-scancode-bison-exception-2.0"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
   - id: "ATT"
     categories:
       - "permissive"
@@ -4358,6 +4376,15 @@ categorizations:
       - "property:unchecked"
 
   - id: "LicenseRef-LGPL-2.1-or-later-with-unlimited-linking-exception"
+    categories:
+      - "copyleft-LGPL"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # Duplicate of LicenseRef-LGPL-2.1-or-later-with-unlimited-linking-exception classification 
+  # due to tooling requirements.
+  - id: "LGPL-2.1-or-later WITH LicenseRef-scancode-unlimited-link-exception-lgpl"
     categories:
       - "copyleft-LGPL"
       - "property:include-in-notice-file"


### PR DESCRIPTION
In this PR, several new licenses and license combinations are added, to tackle with ScanCode 31.x UNHANDLED_LICENSE errors.  The licenses are mainly of type "AutoConf exceptions" to GPL licenses.