### PR TITLE
Classifications: Update CC licenses

### DIFF
--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -171,7 +171,7 @@ categories:
     description: >-
       An open source-style license that is typically applied to specification files and has some
       important limitations, such as a prohibition on modifying the licensed work. These licenses
-      usually fall in the free-restricited category. This property enables users an option to
+      usually fall in the free-restricted category. This property enables users an option to
       automatically accept specification licenses, even if free-restricted licenses otherwise
       create rule violations.
 

--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -1483,7 +1483,7 @@ categorizations:
 
   - id: "CC-BY-NC-ND-4.0"
     categories:
-      - "source-available"
+      - "free-restricted"
       - "property:non-commercial"
       - "property:include-in-notice-file"
       - "property:creativecommons"

--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -1471,6 +1471,7 @@ categorizations:
     categories:
       - "copyleft-strong"
       - "property:include-in-notice-file"
+      - "property:creativecommons"
 
   - id: "LicenseRef-scancode-public-domain"
     categories:
@@ -1485,6 +1486,8 @@ categorizations:
       - "source-available"
       - "property:non-commercial"
       - "property:include-in-notice-file"
+      - "property:creativecommons"
+      - "property:no-modifications"
 
   # https://spdx.org/licenses/FSFULLR.html
   - id: "FSFULLR"
@@ -1525,6 +1528,7 @@ categorizations:
     categories:
       - "copyleft-strong"
       - "property:include-in-notice-file"
+      - "property:creativecommons"
 
   - id: "LicenseRef-scancode-commercial-license"
     categories:
@@ -1716,12 +1720,14 @@ categorizations:
       - "source-available"
       - "property:non-commercial"
       - "property:include-in-notice-file"
+      - "property:creativecommons"
 
   - id: "CC-BY-NC-SA-2.5"
     categories:
       - "source-available"
       - "property:non-commercial"
       - "property:include-in-notice-file"
+      - "property:creativecommons"
 
   - id: "LicenseRef-scancode-ubuntu-font-1.0"
     categories:


### PR DESCRIPTION
## Add missing properties to CC licenses

The new `property:creativecommons` and `property:no-modifications` from PR #43 have not been applied to all appropriate `CC` licenses. This MR adjust the properties of the licenses, which were missed.

~~## Set all CC-SA to copyleft-strong~~

~~This MR sets all `CC-SA` style licenses to `copyleft-strong`.
With `property:no-modifications` and `property:non-commercial`, any `ND` and `NC` properties are atteched to classified licenses. So there is no need to keep `free-restricted` as the category of the `CC-N*-SA` licenses. Instead the class `copyleft-strong` is used to mark the copyleft obligation of a `SA` license.~~

Signed-off-by: Jens Keim <jens.keim@forvia.com>

For more details see Issue https://github.com/doubleopen-project/policy-configuration/issues/36#issuecomment-1714156156 .