### PR TITLE
Use the lean `orth` distribution to list license categories

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,18 +12,27 @@ on:
     branches:
       - "main"
 
+env:
+  ORT_VERSION: 6.0.0
+
 jobs:
   Check:
     runs-on: ubuntu-latest
-    container:
-      image: doubleopen/ort:poc-0.1.2
 
     steps:
       - name: Clone the repository
         uses: actions/checkout@v2
-      - name: Check license-classifications.yml
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Setup ORT helper-cli
         run: |
-          /opt/ort/bin/orth list-license-categories -i license-classifications.yml
+          wget https://github.com/oss-review-toolkit/ort/releases/download/$ORT_VERSION/orth-$ORT_VERSION.zip
+          unzip orth-$ORT_VERSION.zip -d /opt
+      - name: Check license-classifications.yml
+        run: /opt/orth-$ORT_VERSION/bin/orth list-license-categories -i license-classifications.yml
 
   Lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,3 +33,5 @@ jobs:
         uses: actions/checkout@v2
       - name: Lint YAML files
         uses: ibiqlik/action-yamllint@v3
+        with:
+          file_or_dir: license-classifications.yml


### PR DESCRIPTION
This should be much faster than downloading the Docker image.