### PR TITLE
Sort licenses

### DIFF
--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -188,6 +188,50 @@ categories:
       license reviews progress. Contributions/pull requests are welcome.
 
 categorizations:
+  - id: "0BSD"
+    categories:
+      - "permissive"
+
+  - id: "389-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/AFL-1.1.html
+  - id: "AFL-1.1"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:patent-clause"
+
+  # https://spdx.org/licenses/AFL-1.2.html
+  - id: "AFL-1.2"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:patent-clause"
+
+  - id: "AFL-2.0"
+    categories:
+      - "permissive"
+      - "property:distribute-source-code"
+      - "property:include-in-notice-file"
+      - "property:patent-clause"
+
+  - id: "AFL-2.1"
+    categories:
+      - "permissive"
+      - "property:distribute-source-code"
+      - "property:include-in-notice-file"
+      - "property:patent-clause"
+
+  # https://spdx.org/licenses/AFL-3.0.html
+  - id: "AFL-3.0"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:patent-clause"
+      - "property:network-clause"
+
   # https://spdx.org/licenses/AGPL-1.0-only.html
   - id: "AGPL-1.0"
     categories:
@@ -242,1501 +286,15 @@ categorizations:
       - "property:distribute-source-code"
       - "property:patent-clause"
 
-  # https://spdx.org/licenses/Apache-2.0.html
-  - id: "Apache-2.0"
+  - id: "AMD"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
-      - "property:patent-clause"
 
-  # https://spdx.org/licenses/Intel.html
-  - id: "Intel"
+  # https://spdx.org/licenses/AMDPLPA.html
+  - id: "AMDPLPA"
     categories:
       - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/Artistic-1.0.html
-  - id: "Artistic-1.0"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:artistic-license"
-
-  # https://spdx.org/licenses/Artistic-2.0.html
-  - id: "Artistic-2.0"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "property:artistic-license"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/BSD-1-Clause.html
-  - id: "BSD-1-Clause"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/BSD-2-Clause.html
-  - id: "BSD-2-Clause"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://github.com/nexB/scancode-licensedb/blob/main/docs/bsd-2-clause-freebsd.yml
-  - id: "BSD-2-Clause-FreeBSD"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://github.com/nexB/scancode-licensedb/blob/main/docs/bsd-2-clause-netbsd.yml
-  - id: "BSD-2-Clause-NetBSD"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "BSD-4-Clause-NetBSD"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-BSD-4-Clause-NetBSD"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "BSD-4-Clause-Shortened"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/BSD-4.3TAHOE.html
-  - id: "BSD-4.3TAHOE"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:no-modifications"
-      - "property:advertising-clause"
-
-  - id: "LicenseRef-scancode-bsd-original-uc-1986"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "Zend-2.0"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:advertising-clause"
-
-  - id: "BSD-3-Clause-No-Nuclear-Warranty"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:nuclear-restriction"
-
-  - id: "LicenseRef-scancode-bitzi-pd"
-    categories:
-      - "permissive"
-
-  - id: "LicenseRef-scancode-cve-tou"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "NIST-PD"
-    categories:
-      - "public-domain"
-
-  - id: "LicenseRef-scancode-blas-2017"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "BUSL-1.1"
-    categories:
-      - "commercial"
-      - "property:include-in-notice-file"
-
-  - id: "FreeImage"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-
-  - id: "Xerox"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-sun-bsd-extra"
-    categories:
-      - "free-restricted"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/BSD-3-Clause.html
-  - id: "BSD-3-Clause"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/BSD-4-Clause.html
-  - id: "BSD-4-Clause"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:advertising-clause"
-
-  # https://spdx.org/licenses/BSD-4-Clause-UC.html
-  - id: "BSD-4-Clause-UC"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/CC-BY-1.0.html
-  - id: "CC-BY-1.0"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:creativecommons"
-
-  # https://spdx.org/licenses/CC-BY-2.0.html
-  - id: "CC-BY-2.0"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:creativecommons"
-
-  # https://spdx.org/licenses/CC-BY-2.5.html
-  - id: "CC-BY-2.5"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:creativecommons"
-
-  # https://spdx.org/licenses/CC-BY-3.0.html
-  - id: "CC-BY-3.0"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:creativecommons"
-
-  # https://spdx.org/licenses/CC-BY-4.0.html
-  - id: "CC-BY-4.0"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:creativecommons"
-
-  # https://spdx.org/licenses/CC0-1.0.html
-  - id: "CC0-1.0"
-    categories:
-      - "public-domain"
-      - "property:creativecommons"
-
-  # https://spdx.org/licenses/CDDL-1.0.html
-  - id: "CDDL-1.0"
-    categories:
-      - "copyleft-file-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/CDDL-1.1.html
-  - id: "CDDL-1.1"
-    categories:
-      - "copyleft-file-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/EPL-1.0.html
-  - id: "EPL-1.0"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/EPL-2.0.html
-  - id: "EPL-2.0"
-    categories:
-      - "copyleft-file-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/EUPL-1.1.html
-  - id: "EUPL-1.1"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:network-clause"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/EUPL-1.2.html
-  - id: "EUPL-1.2"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:network-clause"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/GPL-1.0-or-later.html
-  - id: "GPL-1.0+"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/GPL-1.0-only.html
-  - id: "GPL-1.0-only"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/GPL-1.0-only.html
-  - id: "GPL-1.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/GPL-1.0-or-later.html
-  - id: "GPL-1.0-or-later"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/GPL-2.0-only.html
-  - id: "GPL-2.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/GPL-2.0-or-later.html
-  - id: "GPL-2.0+"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/GPL-2.0-only.html
-  - id: "GPL-2.0-only"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/GPL-2.0-only.html
-  # https://spdx.org/licenses/Classpath-exception-2.0.html
-  - id: "GPL-2.0-only WITH Classpath-exception-2.0"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "GPL-2.0-only WITH Linux-syscall-note"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-only.html
-  # https://scancode-licensedb.aboutcode.org/mysql-linking-exception-2018.html
-  - id: "GPL-2.0-only WITH LicenseRef-scancode-mysql-linking-exception-2018"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-or-later.html
-  # https://spdx.org/licenses/Autoconf-exception-generic.html
-  - id: "GPL-2.0-or-later WITH Autoconf-exception-generic"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-or-later.html
-  # https://spdx.org/licenses/Classpath-exception-2.0.html
-  - id: "GPL-2.0-or-later WITH Classpath-exception-2.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-only.html
-  # https://spdx.org/licenses/Classpath-exception-2.0.html
-  - id: "GPL-2.0 WITH Classpath-exception-2.0"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://scancode-licensedb.aboutcode.org/oracle-openjdk-classpath-exception-2.0.html
-  - id: "LicenseRef-scancode-oracle-openjdk-classpath-exception-2.0"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-only.html
-  # https://spdx.org/licenses/OpenJDK-assembly-exception-1.0.html
-  - id: "GPL-2.0 WITH OpenJDK-assembly-exception-1.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-only.html
-  # https://spdx.org/licenses/Font-exception-2.0.html
-  - id: "GPL-2.0-only WITH Font-exception-2.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-only.html
-  # https://spdx.org/licenses/Universal-FOSS-exception-1.0.html
-  - id: "GPL-2.0-only WITH Universal-FOSS-exception-1.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-only.html
-  - id: "LicenseRef-gpl-2.0-or-later-with-ada-linking-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-or-later.html
-  - id: "GPL-2.0-or-later"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/GPL-3.0-only.html
-  - id: "GPL-3.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/GPL-3.0-or-later.html
-  - id: "GPL-3.0+"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/GPL-3.0-only.html
-  - id: "GPL-3.0-only"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/GPL-3.0-or-later.html
-  - id: "GPL-3.0-or-later"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/Latex2e.html
-  - id: "Latex2e"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "property:unchecked"
-
-  # https://spdx.org/licenses/GFDL-1.1.html
-  - id: "GFDL-1.1"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "property:unchecked"
-
-  # https://spdx.org/licenses/GFDL-1.1.html
-  - id: "GFDL-1.1-or-later"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "property:unchecked"
-
-  # https://spdx.org/licenses/GFDL-1.1.html
-  - id: "GFDL-1.1-only"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "property:unchecked"
-
-  # https://spdx.org/licenses/GFDL-1.2.html
-  - id: "GFDL-1.2-or-later"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "property:unchecked"
-
-  # https://spdx.org/licenses/GFDL-1.2.html
-  - id: "GFDL-1.2"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "property:unchecked"
-
-  # https://spdx.org/licenses/GFDL-1.3.html
-  - id: "GFDL-1.3"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "property:unchecked"
-
-  # https://spdx.org/licenses/GFDL-1.3.html
-  - id: "GFDL-1.3-or-later"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "property:unchecked"
-
-  # https://spdx.org/licenses/GFDL-1.3.html
-  - id: "GFDL"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "property:unchecked"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-GFDL"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "property:unchecked"
-
-  # https://spdx.org/licenses/JSON.html
-  - id: "JSON"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/LGPL-2.0-only.html
-  - id: "LGPL-2.0-only"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/LGPL-2.0-or-later.html
-  - id: "LGPL-2.0-or-later"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/LGPL-2.1-only.html
-  - id: "LGPL-2.1-only"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/LGPL-2.1-only.html
-  # https://spdx.org/licenses/Linux-syscall-note.html
-  - id: "LGPL-2.1 WITH Linux-syscall-note"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/LGPL-2.1-or-later.html
-  - id: "LGPL-2.1-or-later"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/LGPL-2.1-or-later.html
-  # https://spdx.org/licenses/Linux-syscall-note.html
-  - id: "LGPL-2.1-or-later WITH Linux-syscall-note"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/LGPL-3.0-only.html
-  - id: "LGPL-3.0-only"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/LGPL-3.0-or-later.html
-  - id: "LGPL-3.0-or-later"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/LGPL-3.0-only.html
-  - id: "LGPL-3.0"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/Libpng.html
-  - id: "Libpng"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/MIT.html
-  - id: "MIT"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/IJG.html
-  - id: "IJG"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/MIT-0.html
-  - id: "MIT-0"
-    categories:
-      - "permissive"
-
-  # https://spdx.org/licenses/MIT-open-group.html
-  - id: "MIT-open-group"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/MIT-feh.html
-  - id: "MIT-feh"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/MPL-1.0.html
-  - id: "MPL-1.0"
-    categories:
-      - "copyleft-file-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/MPL-1.1.html
-  - id: "MPL-1.1"
-    categories:
-      - "copyleft-file-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/NPL-1.1.html
-  - id: "NPL-1.1"
-    categories:
-      - "copyleft-file-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/MPL-2.0.html
-  - id: "MPL-2.0"
-    categories:
-      - "copyleft-file-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/CUA-OPL-1.0.html
-  - id: "CUA-OPL-1.0"
-    categories:
-      - "copyleft-file-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/MS-PL.html
-  - id: "MS-PL"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/MS-RL.html
-  - id: "MS-RL"
-    categories:
-      - "copyleft-file-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/ODbL-1.0.html
-  - id: "ODbL-1.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/OFL-1.0.html
-  - id: "OFL-1.0"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/OFL-1.1.html
-  - id: "OFL-1.1"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/OFL-1.1-no-RFN.html
-  - id: "OFL-1.1-no-RFN"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/OpenSSL.html
-  - id: "OpenSSL"
-    categories:
-      - "permissive"
-      - "property:advertising-clause"
-      - "property:include-in-notice-file"
-
-  # https://www.python.org/download/releases/2.1.1/license/
-  - id: "Python-2.1.1"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/Python-2.0.html
-  - id: "Python-2.0"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/Ruby.html
-  - id: "Ruby"
-    categories:
-      - "copyleft-file-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/SAX-PD.html
-  - id: "SAX-PD"
-    categories:
-      - "public-domain"
-
-  # https://spdx.org/licenses/Unlicense.html
-  - id: "Unlicense"
-    categories:
-      - "public-domain"
-
-  # https://spdx.org/licenses/W3C.html
-  - id: "W3C"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/W3C-20150513.html
-  - id: "W3C-20150513"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/W3C.html
-  - id: "W3C-style"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/W3C.html
-  - id: "LicenseRef-W3C-style"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/WTFPL.html
-  - id: "WTFPL"
-    categories:
-      - "public-domain"
-
-  # https://spdx.org/licenses/X11.html
-  - id: "X11"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/Zlib.html
-  - id: "Zlib"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/zlib-acknowledgement.html
-  - id: "zlib-acknowledgement"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/Zlib.html
-  - id: "Zlib-style"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/bzip2-1.0.5.html
-  - id: "bzip2-1.0.5"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/bzip2-1.0.5.html
-  - id: "bzip2-1.0.6"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/curl.html
-  - id: "curl"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/Apache-1.1.html
-  - id: "Apache-1.1"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/Apache-1.0.html
-  - id: "Apache-1.0"
-    categories:
-      - "permissive"
-      - "property:advertising-clause"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/Artistic-1.0-Perl.html
-  - id: "Artistic-1.0-Perl"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/CC-PDDC.html
-  - id: "CC-PDDC"
-    categories:
-      - "public-domain"
-
-  # https://spdx.org/licenses/CNRI-Jython.html
-  - id: "CNRI-Jython"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/CNRI-Python.html
-  - id: "CNRI-Python"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/CPL-1.0.html
-  - id: "CPL-1.0"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/FSFAP.html
-  - id: "FSFAP"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/HPND.html
-  - id: "HPND"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/HPND-sell-variant.html
-  - id: "HPND-sell-variant"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/IBM-pibs.html
-  - id: "IBM-pibs"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/Info-ZIP.html
-  - id: "Info-ZIP"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/IPL-1.0.html
-  - id: "IPL-1.0"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/ISC.html
-  - id: "ISC"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/LPL-1.02.html
-  - id: "LPL-1.02"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/LPPL-1.0.html
-  - id: "LPPL-1.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/LPPL-1.0.html
-  - id: "LPPL-1.0+"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/LPPL-1.0.html
-  - id: "LPPL-1.0-or-later"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/LPPL-1.2.html
-  - id: "LPPL-1.2"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/LPPL-1.2.html
-  - id: "LPPL-1.2+"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/LPPL-1.2.html
-  - id: "LPPL-1.2-or-later"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/LPPL-1.3c.html
-  - id: "LPPL-1.3c"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/ICU.html
-  - id: "ICU"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://scancode-licensedb.aboutcode.org/bsd-3-clause-no-change.html
-  - id: "LicenseRef-scancode-bsd-3-clause-no-change"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://github.com/nexB/scancode-toolkit/blob/ded56e9120f5fdfb9a1a0309130bb4305a66aacb/src/licensedcode/data/licenses/red-hat-attribution.LICENSE
-  - id: "LicenseRef-scancode-red-hat-attribution"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://github.com/nexB/scancode-toolkit/blob/ded56e9120f5fdfb9a1a0309130bb4305a66aacb/src/licensedcode/data/licenses/ogc.LICENSE
-  - id: "LicenseRef-scancode-ogc"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://github.com/nexB/scancode-toolkit/blob/ded56e9120f5fdfb9a1a0309130bb4305a66aacb/src/licensedcode/data/licenses/mit-no-advert-export-control.LICENSE
-  - id: "LicenseRef-scancode-mit-no-advert-export-control"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://github.com/nexB/scancode-toolkit/blob/ded56e9120f5fdfb9a1a0309130bb4305a66aacb/src/licensedcode/data/licenses/snprintf.LICENSE
-  - id: "LicenseRef-scancode-snprintf"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/snprintf.html
-  - id: "snprintf"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://github.com/nexB/scancode-toolkit/blob/ded56e9120f5fdfb9a1a0309130bb4305a66aacb/src/licensedcode/data/licenses/philippe-de-muyter.LICENSE
-  - id: "LicenseRef-scancode-philippe-de-muyter"
-    categories:
-      - "permissive"
-
-  # https://scancode-licensedb.aboutcode.org/bsd-axis-nomod.html
-  - id: "LicenseRef-scancode-bsd-axis-nomod"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://scancode-licensedb.aboutcode.org/docbook.html
-  - id: "LicenseRef-scancode-docbook"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://scancode-licensedb.aboutcode.org/ecma-documentation.html
-  - id: "LicenseRef-scancode-ecma-documentation"
-    categories:
-      - "free-restricted"
-      - "property:include-in-notice-file"
-
-  # https://scancode-licensedb.aboutcode.org/efsl-1.0.html
-  - id: "LicenseRef-scancode-efsl-1.0"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-
-  # https://scancode-licensedb.aboutcode.org/h2-1.0.html
-  - id: "LicenseRef-scancode-h2-1.0"
-    categories:
-      - "copyleft-file-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://scancode-licensedb.aboutcode.org/ietf.html
-  - id: "LicenseRef-scancode-ietf"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://scancode-licensedb.aboutcode.org/ietf-trust.html
-  - id: "LicenseRef-scancode-ietf-trust"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://scancode-licensedb.aboutcode.org/iso-8879.html
-  - id: "LicenseRef-scancode-iso-8879"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://scancode-licensedb.aboutcode.org/jdom.html
-  - id: "LicenseRef-scancode-jdom"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://scancode-licensedb.aboutcode.org/jpython-1.1.html
-  - id: "LicenseRef-scancode-jpython-1.1"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://scancode-licensedb.aboutcode.org/jython.html
-  - id: "LicenseRef-scancode-jython"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://scancode-licensedb.aboutcode.org/libpbm.html
-  - id: "LicenseRef-scancode-libpbm"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://scancode-licensedb.aboutcode.org/mit-specification-disclaimer.html
-  - id: "LicenseRef-scancode-mit-specification-disclaimer"
-    categories:
-      - "permissive"
-
-  # https://scancode-licensedb.aboutcode.org/ms-ws-routing-spec.html
-  - id: "LicenseRef-scancode-ms-ws-routing-spec"
-    categories:
-      - "permissive"
-
-  # https://scancode-licensedb.aboutcode.org/oasis-ws-security-spec.html
-  - id: "LicenseRef-scancode-oasis-ws-security-spec"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://scancode-licensedb.aboutcode.org/openssl.html
-  - id: "LicenseRef-scancode-openssl"
-    categories:
-      - "permissive"
-      - "property:advertising-clause"
-      - "property:include-in-notice-file"
-
-  # https://scancode-licensedb.aboutcode.org/other-permissive.html
-  - id: "LicenseRef-scancode-other-permissive"
-    categories:
-      - "permissive"
-
-  # https://scancode-licensedb.aboutcode.org/proprietary-license.html
-  - id: "LicenseRef-scancode-proprietary-license"
-    categories:
-      - "commercial"
-
-  # https://scancode-licensedb.aboutcode.org/protobuf.html
-  - id: "LicenseRef-scancode-protobuf"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://scancode-licensedb.aboutcode.org/public-domain-disclaimer.html
-  - id: "LicenseRef-scancode-public-domain-disclaimer"
-    categories:
-      - "public-domain"
-
-  # https://scancode-licensedb.aboutcode.org/service-comp-arch.html
-  - id: "LicenseRef-scancode-service-comp-arch"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-sun-jsr-spec-04-2006"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-jsr-107-jcache-spec-2013"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-sun-ejb-spec-3.0"
-    categories:
-      - "proprietary-free"
-      - "property:patent-clause"
-
-  - id: "LicenseRef-scancode-sun-sdk-spec-1.1"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-taligent-jdk"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-unicode"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-unicode-mappings"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-w3c-docs-20021231"
-    categories:
-      - "free-restricted"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-apple-sscl"
-    categories:
-      - "permissive"
-
-  - id: "LicenseRef-scancode-python-cwi"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-ldpgpl-1a"
-    categories:
-      - "copyleft-file-level"
-      - "property:include-in-notice-file"
-
-  - id: "Vim"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-ws-addressing-spec"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-ws-policy-specification"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-ws-trust-specification"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-x11-hanson"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-x11-lucent"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-x11-opengroup"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "NOSL"
-    categories:
-      - "copyleft-file-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  - id: "Plexus"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "Saxpath"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "W3C-19980720"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "CC-BY-SA-3.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:creativecommons"
-
-  - id: "LicenseRef-scancode-public-domain"
-    categories:
-      - "public-domain"
-
-  - id: "LicenseRef-scancode-us-govt-public-domain"
-    categories:
-      - "public-domain"
-
-  - id: "CC-BY-NC-ND-4.0"
-    categories:
-      - "free-restricted"
-      - "property:non-commercial"
-      - "property:include-in-notice-file"
-      - "property:creativecommons"
-      - "property:no-modifications"
-
-  # https://spdx.org/licenses/FSFULLR.html
-  - id: "FSFULLR"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/FSFULLRWD.html
-  - id: "FSFULLRWD"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://scancode-licensedb.aboutcode.org/fsf-unlimited-no-warranty.html
-  - id: "LicenseRef-FSF-Unlimited-No-Warranty"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://scancode-licensedb.aboutcode.org/fsf-unlimited-no-warranty.html
-  - id: "LicenseRef-fsf-unlimited-no-warranty"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-fsf-unlimited-no-warranty"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://scancode-licensedb.aboutcode.org/fsf-unlimited-no-warranty.html
-  - id: "fsf-unlimited-no-warranty"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "CC-BY-SA-4.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:creativecommons"
-
-  - id: "LicenseRef-scancode-commercial-license"
-    categories:
-      - "commercial"
-
-  - id: "Classpath-exception-2.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
-      - "property:include-in-notice-file"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-Classpath-exception-2.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/LLVM-exception.html
-  - id: "LLVM-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-scancode-ada-linking-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "Universal-FOSS-exception-1.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
-      - "property:include-in-notice-file"
-
-  - id: "Autoconf-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "u-boot-exception-2.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-u-boot-exception-2.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-Libtool-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "Libtool-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "TeX-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-TeX-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "openvpn-openssl-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "GPL-3.0-linking-source-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-OpenSSL-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "OpenSSL-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-scancode-mysql-floss-exception-2.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-scancode-warranty-disclaimer"
-    categories:
-      - "irrelevant"
-
-  - id: "NOT-public-domain"
-    categories:
-      - "irrelevant"
-
-  - id: "GPL-exception"
-    categories:
-      - "irrelevant"
-
-  - id: "Patent-ref"
-    categories:
-      - "irrelevant"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-Patent-ref"
-    categories:
-      - "irrelevant"
-
-  - id: "LicenseRef-NOT-public-domain"
-    categories:
-      - "irrelevant"
-
-  - id: "LicenseRef-scancode-generic-cla"
-    categories:
-      - "irrelevant"
-
-  - id: "LicenseRef-scancode-generic-export-compliance"
-    categories:
-      - "irrelevant"
-
-  - id: "LicenseRef-scancode-tex-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-autoconf-macro-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-dco-1.1"
-    categories:
-      - "irrelevant"
-
-  - id: "LicenseRef-scancode-other-copyleft"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-autoconf-simple-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-jetty-ccla-1.1"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:patent-clause"
-
-  - id: "LicenseRef-scancode-newton-king-cla"
-    categories:
-      - "unstated"
-
-  - id: "BSD-3-Clause-Open-MPI"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-bsd-x11"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-zipeg"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-openjdk-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-unknown-spdx"
-    categories:
-      - "unstated"
-
-  - id: "BSD-2-Clause-Views"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "PostgreSQL"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "Noweb"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-
-  - id: "CC-BY-NC-SA-4.0"
-    categories:
-      - "source-available"
-      - "property:non-commercial"
-      - "property:include-in-notice-file"
-      - "property:creativecommons"
-
-  - id: "CC-BY-NC-SA-2.5"
-    categories:
-      - "source-available"
-      - "property:non-commercial"
-      - "property:include-in-notice-file"
-      - "property:creativecommons"
-
-  - id: "LicenseRef-scancode-ubuntu-font-1.0"
-    categories:
-      - "free-restricted"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-ubuntu-font-1.0"
-    categories:
-      - "free-restricted"
       - "property:include-in-notice-file"
 
   - id: "ANTLR-PD"
@@ -1744,1533 +302,7 @@ categorizations:
       - "permissive"
       - "property:include-in-notice-file"
 
-  # https://spdx.org/licenses/FSFUL.html
-  - id: "FSFUL"
-    categories:
-      - "permissive"
-
-  - id: "LicenseRef-scancode-autoconf-simple-exception-2.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-sun-prop-non-commercial"
-    categories:
-      - "proprietary-free"
-      - "property:non-commercial"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/NTP.html
-  - id: "NTP"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-CMU"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "CMU"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "CMU-style"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-CMU-style"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-bsd-1988"
-    categories:
-      - "property:unchecked"
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-ldap-sdk-free-use"
-    categories:
-      - "property:unchecked"
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-mit-license-1998"
-    categories:
-      - "property:unchecked"
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-osf-1990"
-    categories:
-      - "property:unchecked"
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-rsa-1990"
-    categories:
-      - "property:unchecked"
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-rsa-md4"
-    categories:
-      - "permissive"
-      - "property:advertising-clause"
-      - "property:include-in-notice-file"
-
-  - id: "RSA-Cryptoki"
-    categories:
-      - "permissive"
-      - "property:advertising-clause"
-      - "property:include-in-notice-file"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-RSA-Cryptoki"
-    categories:
-      - "permissive"
-      - "property:advertising-clause"
-      - "property:include-in-notice-file"
-
-  - id: "RSA-MD"
-    categories:
-      - "property:advertising-clause"
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "TMate"
-    categories:
-      - "property:unchecked"
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-mit-old-style"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "scancode-mit-old-style"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "MPL-2.0-no-copyleft-exception"
-    categories:
-      - "copyleft-file-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  - id: "LicenseRef-scancode-bsd-no-disclaimer"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-minpack"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "Minpack"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "Linux-OpenIB"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
   - id: "APAFML"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "Adobe-Glyph"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-freemarker"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-indiana-extreme"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-w3c-docs-19990405"
-    categories:
-      - "property:unchecked"
-      - "free-restricted"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-W3C-copyright-documents-19990405"
-    categories:
-      - "property:unchecked"
-      - "free-restricted"
-      - "property:include-in-notice-file"
-
-  - id: "CC-BY-SA-2.5"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:creativecommons"
-
-  - id: "CC-BY-SA-2.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:creativecommons"
-
-  - id: "PSF-2.0"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-bakoma-fonts-1995"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-bitstream"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-boost-original"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-llnl"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-psf-3.7.2"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-secret-labs-2011"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "NCSA"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "Qhull"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "TCL"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-bsla"
-    categories:
-      - "property:advertising-clause"
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-sunpro"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-ekioh"
-    categories:
-      - "permissive"
-
-  - id: "LicenseRef-scancode-mit-nagy"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "Font-exception-2.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-Font-exception-2.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-Elfutils-Exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-scancode-mit-modern"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-srgb"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/LGPL-3.0-or-later.html
-  # https://spdx.org/licenses/openvpn-openssl-exception.html
-  - id: "LGPL-3.0-or-later WITH openvpn-openssl-exception"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/LGPL-3.0-or-later.html
-  # https://spdx.org/licenses/openvpn-openssl-exception.html
-  - id: "LicenseRef-scancode-openssl-exception-lgpl-3.0-plus"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-scancode-mit-synopsys"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/MIT-CMU.html
-  - id: "MIT-CMU"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "ZPL-2.1"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "BSD-3-Clause-LBNL"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "BSL-1.0"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LPPL-1.3a"
-    categories:
-      - "property:unchecked"
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  - id: "LicenseRef-scancode-mozilla-gc"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "Beerware"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/GPL-1.0-or-later.html
-  # https://spdx.org/licenses/Linux-syscall-note.html
-  - id: "GPL-1.0-or-later WITH Linux-syscall-note"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-1.0-or-later.html
-  # https://spdx.org/licenses/Autoconf-exception-generic.html
-  - id: "GPL-1.0-or-later WITH Autoconf-exception-generic"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-or-later.html
-  # https://spdx.org/licenses/Linux-syscall-note.html
-  - id: "GPL-2.0-or-later WITH Linux-syscall-note"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-or-later.html
-  # https://spdx.org/licenses/eCos-exception-2.0.html
-  - id: "GPL-2.0-or-later WITH eCos-exception-2.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-only.html
-  # https://spdx.org/licenses/Linux-syscall-note.html
-  - id: "GPL-2.0 WITH Linux-syscall-note"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-Public-domain"
-    categories:
-      - "public-domain"
-
-  - id: "LicenseRef-other-permissive"
-    categories:
-      - "permissive"
-
-  - id: "AFL-2.1"
-    categories:
-      - "permissive"
-      - "property:distribute-source-code"
-      - "property:include-in-notice-file"
-      - "property:patent-clause"
-
-  - id: "AFL-2.0"
-    categories:
-      - "permissive"
-      - "property:distribute-source-code"
-      - "property:include-in-notice-file"
-      - "property:patent-clause"
-
-  - id: "SSH-short"
-    categories:
-      - "permissive"
-
-  - id: "LicenseRef-bzip2"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "bzip2"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/GPL-3.0-or-later.html
-  # https://spdx.org/licenses/Bison-exception-2.2.html
-  - id: "GPL-3.0-or-later WITH Bison-exception-2.2"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-3.0-or-later.html
-  # http://git.openembedded.org/openembedded-core/tree/meta/files/common-licenses/GPL-2.0-with-autoconf-exception
-  - id: "GPL-3.0-or-later-with-Autoconf-macro-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-3.0-or-later.html
-  # https://scancode-licensedb.aboutcode.org/autoconf-macro-exception.html
-  - id: "GPL-3.0-or-later WITH LicenseRef-scancode-autoconf-macro-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-3.0-only.html
-  # https://spdx.org/licenses/Autoconf-exception-3.0.html
-  - id: "GPL-3.0-only WITH Autoconf-exception-3.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-3.0-only.html
-  # https://spdx.org/licenses/GCC-exception-3.1.html
-  - id: "GPL-3.0-only WITH GCC-exception-3.1"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-3.0-or-later.html
-  # https://spdx.org/licenses/GCC-exception-3.1.html
-  - id: "GPL-3.0-or-later WITH GCC-exception-3.1"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-3.0-or-later.html
-  - id: "LicenseRef-GPL-3.0-or-later-with-TeX-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-3.0-or-later.html
-  - id: "LicenseRef-GPL-3.0-or-later-with-Autoconf-macro-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-or-later.html
-  # https://spdx.org/licenses/Bison-exception-2.2.html
-  - id: "GPL-2.0-or-later WITH Bison-exception-2.2"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-or-later.html
-  - id: "LicenseRef-GPL-2.0-or-later-with-TeX-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-or-later.html
-  - id: "LicenseRef-GPL-2.0-or-later-with-autoconf-macro-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-or-later.html
-  # https://github.com/gpg/libgpg-error/blob/220a427b4f997ef6af1b2d4e82ef1dc96e0cd6ff/lang/cl/mkerrcodes.awk
-  - id: "LicenseRef-GPL-2.0-or-later-with-mkerrcodes.awk-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-or-later.html
-  # https://spdx.org/licenses/openvpn-openssl-exception.html
-  - id: "LicenseRef-GPL-2.0-with-openssl-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://www.openldap.org/software/release/license.html
-  - id: "LicenseRef-OpenLDAP"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/OLDAP-2.0.1.html
-  - id: "OLDAP-2.0.1"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/OLDAP-2.8.html
-  - id: "OLDAP-2.8"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # http://pcre.sourceforge.net/license.txt
-  - id: "LicenseRef-PCRE"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:unchecked"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "PCRE"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:unchecked"
-
-  # https://spdx.org/licenses/GPL-2.0-or-later.html
-  # https://spdx.org/licenses/openvpn-openssl-exception.html
-  - id: "LicenseRef-GPL-2.0-with-OpenSSL-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-SunPro"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "NTP-0"
-    categories:
-      - "permissive"
-
-  - id: "LicenseRef-BSD-1-Clause-No-Notice-Requirements"
-    categories:
-      - "permissive"
-
-  # https://spdx.org/licenses/LGPL-2.0-or-later.html
-  # https://spdx.org/licenses/Linux-syscall-note.html
-  - id: "LGPL-2.0-or-later WITH Linux-syscall-note"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "0BSD"
-    categories:
-      - "permissive"
-
-  - id: "Public-domain"
-    categories:
-      - "public-domain"
-
-  # https://spdx.org/licenses/LGPL-2.1-only.html
-  - id: "LGPL-2.1"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  - id: "Public-domainC"
-    categories:
-      - "public-domain"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-Public-domainC"
-    categories:
-      - "public-domain"
-
-  - id: "blessing"
-    categories:
-      - "public-domain"
-
-  - id: "LicenseRef-BSD-1-Clause-No-Notice-Requirement"
-    categories:
-      - "permissive"
-
-  - id: "Freeware"
-    categories:
-      - "proprietary-free"
-
-  - id: "Free-SW"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/LGPL-2.0-only.html
-  - id: "LGPL-2.0"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  - id: "IBM-dhcp"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-IBM-dhcp"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "FSF"
-    categories:
-      - "permissive"
-
-  - id: "LicenseRef-FSF"
-    categories:
-      - "permissive"
-
-  - id: "SunPro"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "GCC-exception-2.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-GCC-exception-2.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "Bootloader-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-Bootloader-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "GCC-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-GCC-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "GCC-exception-3.1"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-GCC-exception-3.1"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-only.html
-  # https://spdx.org/licenses/GCC-exception-2.0.html
-  - id: "GPL-2.0-with-GCC-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "GPL-2.0-or-later WITH GCC-exception-2.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "GPL-2.0-only WITH GCC-exception-2.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "GPL-2.0-or-later-with-autoconf-macro-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LGPL-2.1-or-later WITH GCC-exception-2.0"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "linking-exception"
-    categories:
-      - "property:unchecked"
-      - "property:AutoConf-or-other-exception"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-linking-exception"
-    categories:
-      - "property:unchecked"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-InnerNet-2.00"
-    categories:
-      - "property:unchecked"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "InnerNet-2.00"
-    categories:
-      - "property:unchecked"
-
-  - id: "Public-domain-ref "
-    categories:
-      - "public-domain"
-
-  # https://spdx.org/licenses/GPL-2.0-or-later.html
-  # https://spdx.org/licenses/Autoconf-exception-2.0.html
-  - id: "GPL-2.0-or-later WITH Autoconf-exception-2.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "GPL-2.0-or-later-WITH-Autoconf-exception-2.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-or-later.html
-  # https://spdx.org/licenses/Libtool-exception.html
-  - id: "GPL-2.0-or-later WITH Libtool-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "NewBSD"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-NewBSD"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "st-mcd-2.0"
-    categories:
-      - "free-restricted"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-st-mcd-2.0"
-    categories:
-      - "free-restricted"
-      - "property:include-in-notice-file"
-
-  - id: "BSD-Source-Code"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "Cryptogams"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-Cryptogams"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "389-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-389-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "Bison-exception-2.2"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "Bison-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-Bison-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-Bison-exception-2.2"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-3.0-or-later.html
-  # https://spdx.org/licenses/Bison-exception-2.2.html
-  - id: "GPL-3.0-or-later-WITH-Bison-exception-2.2"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-3.0-or-later.html
-  # https://spdx.org/licenses/Autoconf-exception-generic.html
-  - id: "GPL-3.0-or-later WITH Autoconf-exception-generic"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-3.0-or-later.html
-  # https://spdx.org/licenses/Autoconf-exception-2.0.html
-  - id: "GPL-3.0-or-later WITH Autoconf-exception-2.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-3.0-or-later.html
-  # https://spdx.org/licenses/Autoconf-exception-3.0.html
-  - id: "GPL-3.0-or-later WITH Autoconf-exception-3.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-3.0-or-later.html
-  # https://spdx.org/licenses/Libtool-exception.html
-  - id: "GPL-3.0-or-later WITH Libtool-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-3.0-or-later.html
-  # https://scancode-licensedb.aboutcode.org/autoconf-simple-exception.html
-  - id: "GPL-3.0-or-later WITH LicenseRef-scancode-autoconf-simple-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-3.0-or-later.html
-  # https://scancode-licensedb.aboutcode.org/tex-exception.html
-  - id: "GPL-3.0-or-later WITH LicenseRef-scancode-tex-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-or-later.html
-  # https://spdx.org/licenses/Bison-exception-2.2.html
-  - id: "GPL-2.0-or-later-with-bison-exception-2.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-or-later.html
-  # https://spdx.org/licenses/Bison-exception-2.2.html
-  - id: "LicenseRef-GPL-2.0-or-later-with-bison-exception-2.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://scancode-licensedb.aboutcode.org/bison-exception-2.0.html
-  - id: "LicenseRef-scancode-bison-exception-2.0"
-    categories:
-      - "property:include-in-notice-file"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "ATT"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-Rdisc"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "Rdisc"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "Sun-RPC"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "Non-commercial"
-    categories:
-      - "property:unchecked"
-      - "property:non-commercial"
-
-  - id: "BSD-3-Clause-Attribution"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:advertising-clause"
-
-  - id: "Python"
-    categories:
-      - "property:include-in-notice-file"
-      - "permissive"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-Python"
-    categories:
-      - "property:include-in-notice-file"
-      - "permissive"
-
-  # https://github.com/joelagnel/meta-ti/blob/fd86d69fde9203136bd2f22d4f5e7c810f44c42d/licenses/TI-TFL
-  - id: "LicenseRef-TI-TFL"
-    categories:
-      - "property:include-in-notice-file"
-      - "proprietary-free"
-      - "property:unchecked"
-
-  # https://spdx.org/licenses/MTLL.html
-  - id: "MTLL"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-Scanner-WebM"
-    categories:
-      - "property:include-in-notice-file"
-      - "permissive"
-
-  - id: "LicenseRef-WebM"
-    categories:
-      - "property:include-in-notice-file"
-      - "permissive"
-
-  - id: "Debian-SPI-style"
-    categories:
-      - "property:include-in-notice-file"
-      - "permissive"
-
-  - id: "LicenseRef-Debian-SPI-style"
-    categories:
-      - "property:include-in-notice-file"
-      - "permissive"
-
-  - id: "verbatim-distribution-license"
-    categories:
-      - "property:include-in-notice-file"
-      - "permissive"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-verbatim-distribution-license"
-    categories:
-      - "property:include-in-notice-file"
-      - "permissive"
-
-  - id: "gary-s-brown"
-    categories:
-      - "permissive"
-
-  - id: "LicenseRef-gary-s-brown"
-    categories:
-      - "permissive"
-
-  - id: "Apple.Sample"
-    categories:
-      - "permissive"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-Apple.Sample"
-    categories:
-      - "permissive"
-
-  - id: "Apache-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "LGPL-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "RSA-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "GPL-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "Perl-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-Perl-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "Sun-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "HP-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "IJG-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "W3C-possibility"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-W3C-possibility"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "Apache"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-Apache"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "GNU-Manpages"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "ISC-style"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "Linux-syscall-note"
-    categories:
-      - "property:AutoConf-or-other-exception"
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  - id: "LicenseRef-Linux-syscall-note"
-    categories:
-      - "property:AutoConf-or-other-exception"
-      - "copyleft-strong"
-      - "property:distribute-source-code"
-
-  - id: "MIT-old-style-no-adv"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-MIT-old-style-no-adv"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-mit-no-advert-export-control"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-mit-old-style-no-advert"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-Python-2.2"
-    categories:
-      - "property:include-in-notice-file"
-      - "permissive"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "Python-2.2"
-    categories:
-      - "property:include-in-notice-file"
-      - "permissive"
-
-  - id: "IBM-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "DOC"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-Permissive-no-warranty"
-    categories:
-      - "permissive"
-
-  - id: "Permissive-no-warranty"
-    categories:
-      - "permissive"
-
-  # This is needed for the license to (not) be picked correctly for notice generation.
-  - id: "LicenseRef-LicenseRef-Permissive-no-warranty"
-    categories:
-      - "permissive"
-
-  - id: "ubuntu-font-1.0"
-    categories:
-      - "property:include-in-notice-file"
-      - "free-restricted"
-
-  - id: "TCP-wrappers"
-    categories:
-      - "property:include-in-notice-file"
-      - "permissive"
-
-  - id: "GPL"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "LicenseRef-GPL"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "LGPL"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "LicenseRef-LGPL"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "LicenseRef-inner-net-2.0"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:advertising-clause"
-
-  - id: "Microsoft-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "Microsoft"
-    categories:
-      - "proprietary-free"
-
-  - id: "UnclassifiedLicense"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "See-file.LICENSE"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-See-file.LICENSE"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "See-file.README"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-See-file.README"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "Same-license-as"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-Same-license-as"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "See-file"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-See-file"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "See-URL"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-See-URL"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "See-doc.OTHER"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-See-doc.OTHER"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "See-file.COPYING"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-See-file.COPYING"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "MPL"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "LicenseRef-MPL"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  # Inaccurate but permissive license hits.
-  - id: "BSD-style"
-    categories:
-      - "permissive"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-BSD-style"
-    categories:
-      - "permissive"
-
-  - id: "LicenseRef-MIT-style"
-    categories:
-      - "permissive"
-
-  - id: "MIT-style"
-    categories:
-      - "permissive"
-
-  - id: "MIT-CMU-style"
-    categories:
-      - "permissive"
-
-  - id: "LicenseRef-MIT-CMU-style"
-    categories:
-      - "permissive"
-
-  - id: "BSL-style"
-    categories:
-      - "permissive"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-BSL-style"
-    categories:
-      - "permissive"
-
-  - id: "BSD"
-    categories:
-      - "permissive"
-
-  - id: "X11-style"
-    categories:
-      - "permissive"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-X11-style"
-    categories:
-      - "permissive"
-
-  - id: "X11-possibility"
-    categories:
-      - "permissive"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-X11-possibility"
-    categories:
-      - "permissive"
-
-  - id: "ISC-possibility"
-    categories:
-      - "permissive"
-
-  - id: "Zlib-possibility"
-    categories:
-      - "permissive"
-
-  - id: "LicenseRef-Zlib-possibility"
-    categories:
-      - "permissive"
-
-  - id: "LicenseRef-BSD"
-    categories:
-      - "permissive"
-
-  - id: "BSD-possibility"
-    categories:
-      - "permissive"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-BSD-possibility"
-    categories:
-      - "permissive"
-
-  - id: "MIT-possibility"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-MIT-possibility"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-Permissive-attribution"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-MIT-old-style-with-legal-disclaimer"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://github.com/nexB/scancode-licensedb/blob/main/docs/json-js-pd.LICENSE
-  - id: "LicenseRef-scancode-json-js-pd"
-    categories:
-      - "public-domain"
-
-  - id: "LicenseRef-PD"
-    categories:
-      - "public-domain"
-
-  - id: "LicenseRef-Public-domain-ref"
-    categories:
-      - "public-domain"
-
-  # https://spdx.org/licenses/xpp.html
-  - id: "xpp"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:advertising-clause"
-
-  # https://spdx.org/licenses/YPL-1.0.html
-  - id: "YPL-1.0"
-    categories:
-      - "copyleft-file-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://github.com/nexB/scancode-licensedb/blob/main/docs/cc-devnations-2.0.LICENSE
-  - id: "LicenseRef-scancode-cc-devnations-2.0"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/BSD-3-Clause-Clear.html
-  - id: "BSD-3-Clause-Clear"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/JPNIC.html
-  - id: "JPNIC"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://github.com/nexB/scancode-licensedb/blob/main/docs/mx4j.LICENSE
-  - id: "LicenseRef-scancode-mx4j"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://github.com/nexB/scancode-licensedb/blob/main/docs/bsd-simplified-darwin.LICENSE
-  - id: "LicenseRef-scancode-bsd-simplified-darwin"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://github.com/nexB/scancode-licensedb/blob/main/docs/iptc-2006.LICENSE
-  - id: "LicenseRef-scancode-iptc-2006"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/CC-BY-ND-3.0.html
-  - id: "CC-BY-ND-3.0"
-    categories:
-      - "free-restricted"
-      - "property:include-in-notice-file"
-      - "property:creativecommons"
-      - "property:no-modifications"
-
-  # https://github.com/nexB/scancode-licensedb/blob/main/docs/json-pd.LICENSE
-  - id: "LicenseRef-scancode-json-pd"
-    categories:
-      - "public-domain"
-
-  # https://spdx.org/licenses/AFL-1.1.html
-  - id: "AFL-1.1"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/AFL-1.2.html
-  - id: "AFL-1.2"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/AFL-3.0.html
-  - id: "AFL-3.0"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:patent-clause"
-      - "property:network-clause"
-
-  # https://spdx.org/licenses/AMDPLPA.html
-  - id: "AMDPLPA"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
@@ -3315,10 +347,75 @@ categorizations:
       - "property:patent-clause"
       - "property:distribute-source-code"
 
+  - id: "ATT"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
   # https://spdx.org/licenses/Adobe-2006.html
   - id: "Adobe-2006"
     categories:
       - "permissive"
+
+  - id: "Adobe-Glyph"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "Apache"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  # https://spdx.org/licenses/Apache-1.0.html
+  - id: "Apache-1.0"
+    categories:
+      - "permissive"
+      - "property:advertising-clause"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/Apache-1.1.html
+  - id: "Apache-1.1"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/Apache-2.0.html
+  - id: "Apache-2.0"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:patent-clause"
+
+  # https://spdx.org/licenses/Apache-2.0.html
+  # https://spdx.org/licenses/LLVM-exception.html
+  - id: "Apache-2.0 WITH LLVM-exception"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  - id: "Apache-possibility"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "Apple.Sample"
+    categories:
+      - "permissive"
+
+  # https://spdx.org/licenses/Artistic-1.0.html
+  - id: "Artistic-1.0"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:artistic-license"
+
+  # https://spdx.org/licenses/Artistic-1.0-Perl.html
+  - id: "Artistic-1.0-Perl"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
 
   # https://spdx.org/licenses/Artistic-1.0-cl8.html
   - id: "Artistic-1.0-cl8"
@@ -3328,12 +425,21 @@ categorizations:
       - "property:distribute-source-code"
       - "property:artistic-license"
 
-  # https://spdx.org/licenses/Autoconf-exception-2.0.html
-  - id: "Autoconf-exception-2.0"
+  # https://spdx.org/licenses/Artistic-2.0.html
+  - id: "Artistic-2.0"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+      - "property:artistic-license"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  - id: "Autoconf-exception"
     categories:
       - "property:AutoConf-or-other-exception"
 
-  - id: "LicenseRef-Autoconf-exception"
+  # https://spdx.org/licenses/Autoconf-exception-2.0.html
+  - id: "Autoconf-exception-2.0"
     categories:
       - "property:AutoConf-or-other-exception"
 
@@ -3342,20 +448,121 @@ categorizations:
     categories:
       - "property:AutoConf-or-other-exception"
 
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-Autoconf-exception-3.0"
+  - id: "BSD"
     categories:
-      - "property:AutoConf-or-other-exception"
+      - "permissive"
 
-  # https://spdx.org/licenses/Autoconf-exception-3.0.html
-  - id: "gnu-javamail-exception"
+  # https://spdx.org/licenses/BSD-1-Clause.html
+  - id: "BSD-1-Clause"
     categories:
-      - "property:AutoConf-or-other-exception"
+      - "permissive"
+      - "property:include-in-notice-file"
 
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-gnu-javamail-exception"
+  - id: "BSD-2"
     categories:
-      - "property:AutoConf-or-other-exception"
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/BSD-2-Clause.html
+  - id: "BSD-2-Clause"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://github.com/nexB/scancode-licensedb/blob/main/docs/bsd-2-clause-freebsd.yml
+  - id: "BSD-2-Clause-FreeBSD"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://github.com/nexB/scancode-licensedb/blob/main/docs/bsd-2-clause-netbsd.yml
+  - id: "BSD-2-Clause-NetBSD"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "BSD-2-Clause-Views"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/BSD-3-Clause.html
+  - id: "BSD-3-Clause"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "BSD-3-Clause-Attribution"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:advertising-clause"
+
+  # https://spdx.org/licenses/BSD-3-Clause-Clear.html
+  - id: "BSD-3-Clause-Clear"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "BSD-3-Clause-LBNL"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/BSD-3-Clause-Modification.html
+  - id: "BSD-3-Clause-Modification"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:mark-modifications"
+
+  - id: "BSD-3-Clause-No-Nuclear-License"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:nuclear-restriction"
+
+  - id: "BSD-3-Clause-No-Nuclear-Warranty"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:nuclear-restriction"
+
+  - id: "BSD-3-Clause-Open-MPI"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/BSD-4-Clause.html
+  - id: "BSD-4-Clause"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:advertising-clause"
+
+  - id: "BSD-4-Clause-NetBSD"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "BSD-4-Clause-Shortened"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/BSD-4-Clause-UC.html
+  - id: "BSD-4-Clause-UC"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/BSD-4.3TAHOE.html
+  - id: "BSD-4.3TAHOE"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:no-modifications"
+      - "property:advertising-clause"
 
   # https://spdx.org/licenses/BSD-Protection.html
   - id: "BSD-Protection"
@@ -3363,6 +570,47 @@ categorizations:
       - "copyleft-strong"
       - "property:include-in-notice-file"
       - "property:distribute-source-code"
+
+  - id: "BSD-Source-Code"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "BSD-possibility"
+    categories:
+      - "permissive"
+
+  # Inaccurate but permissive license hits.
+  - id: "BSD-style"
+    categories:
+      - "permissive"
+
+  - id: "BSL-1.0"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "BSL-style"
+    categories:
+      - "permissive"
+
+  - id: "BUSL-1.1"
+    categories:
+      - "commercial"
+      - "property:include-in-notice-file"
+
+  - id: "Beerware"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "Bison-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  - id: "Bison-exception-2.2"
+    categories:
+      - "property:AutoConf-or-other-exception"
 
   # https://spdx.org/licenses/BitTorrent-1.0.html
   - id: "BitTorrent-1.0"
@@ -3380,12 +628,17 @@ categorizations:
       - "property:distribute-source-code"
       - "property:patent-clause"
 
+  - id: "Bitstream-Vera"
+    categories:
+      - "free-restricted"
+      - "property:include-in-notice-file"
+
+  - id: "Bootloader-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
   # https://spdx.org/licenses/Borceux.html
   - id: "Borceux"
-    categories:
-      - "permissive"
-
-  - id: "LicenseRef-permissive-no-attribution-requirement"
     categories:
       - "permissive"
 
@@ -3396,6 +649,41 @@ categorizations:
       - "property:include-in-notice-file"
       - "property:distribute-source-code"
       - "property:patent-clause"
+
+  # https://spdx.org/licenses/CC-BY-1.0.html
+  - id: "CC-BY-1.0"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:creativecommons"
+
+  # https://spdx.org/licenses/CC-BY-2.0.html
+  - id: "CC-BY-2.0"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:creativecommons"
+
+  # https://spdx.org/licenses/CC-BY-2.5.html
+  - id: "CC-BY-2.5"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:creativecommons"
+
+  # https://spdx.org/licenses/CC-BY-3.0.html
+  - id: "CC-BY-3.0"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:creativecommons"
+
+  # https://spdx.org/licenses/CC-BY-4.0.html
+  - id: "CC-BY-4.0"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:creativecommons"
 
   # https://spdx.org/licenses/CC-BY-NC-1.0.html
   - id: "CC-BY-NC-1.0"
@@ -3473,6 +761,14 @@ categorizations:
       - "property:creativecommons"
       - "property:no-modifications"
 
+  - id: "CC-BY-NC-ND-4.0"
+    categories:
+      - "free-restricted"
+      - "property:non-commercial"
+      - "property:include-in-notice-file"
+      - "property:creativecommons"
+      - "property:no-modifications"
+
   # https://spdx.org/licenses/CC-BY-NC-SA-1.0.html
   - id: "CC-BY-NC-SA-1.0"
     categories:
@@ -3489,12 +785,26 @@ categorizations:
       - "property:non-commercial"
       - "property:creativecommons"
 
+  - id: "CC-BY-NC-SA-2.5"
+    categories:
+      - "source-available"
+      - "property:non-commercial"
+      - "property:include-in-notice-file"
+      - "property:creativecommons"
+
   # https://spdx.org/licenses/CC-BY-NC-SA-3.0.html
   - id: "CC-BY-NC-SA-3.0"
     categories:
       - "free-restricted"
       - "property:include-in-notice-file"
       - "property:non-commercial"
+      - "property:creativecommons"
+
+  - id: "CC-BY-NC-SA-4.0"
+    categories:
+      - "source-available"
+      - "property:non-commercial"
+      - "property:include-in-notice-file"
       - "property:creativecommons"
 
   # https://spdx.org/licenses/CC-BY-ND-1.0.html
@@ -3521,6 +831,14 @@ categorizations:
       - "property:creativecommons"
       - "property:no-modifications"
 
+  # https://spdx.org/licenses/CC-BY-ND-3.0.html
+  - id: "CC-BY-ND-3.0"
+    categories:
+      - "free-restricted"
+      - "property:include-in-notice-file"
+      - "property:creativecommons"
+      - "property:no-modifications"
+
   # https://spdx.org/licenses/CC-BY-ND-4.0.html
   - id: "CC-BY-ND-4.0"
     categories:
@@ -3529,225 +847,800 @@ categorizations:
       - "property:creativecommons"
       - "property:no-modifications"
 
-  - id: "AMD"
+  - id: "CC-BY-SA-2.0"
     categories:
-      - "permissive"
+      - "copyleft-strong"
       - "property:include-in-notice-file"
+      - "property:creativecommons"
 
-  - id: "BSD-2"
+  - id: "CC-BY-SA-2.5"
     categories:
-      - "permissive"
+      - "copyleft-strong"
       - "property:include-in-notice-file"
+      - "property:creativecommons"
+
+  - id: "CC-BY-SA-3.0"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:creativecommons"
+
+  - id: "CC-BY-SA-4.0"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:creativecommons"
+
+  # https://spdx.org/licenses/CC-PDDC.html
+  - id: "CC-PDDC"
+    categories:
+      - "public-domain"
+
+  # https://spdx.org/licenses/CC0-1.0.html
+  - id: "CC0-1.0"
+    categories:
+      - "public-domain"
+      - "property:creativecommons"
+
+  - id: "CCPL"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  # https://spdx.org/licenses/CDDL-1.0.html
+  - id: "CDDL-1.0"
+    categories:
+      - "copyleft-file-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  # https://spdx.org/licenses/CDDL-1.1.html
+  - id: "CDDL-1.1"
+    categories:
+      - "copyleft-file-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
 
   # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-BSD-2"
+  - id: "CMU"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
 
-  - id: "NotreDame-style"
+  - id: "CMU-style"
     categories:
       - "permissive"
+      - "property:include-in-notice-file"
 
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-NotreDame-style"
+  # https://spdx.org/licenses/CNRI-Jython.html
+  - id: "CNRI-Jython"
     categories:
       - "permissive"
+      - "property:include-in-notice-file"
 
-  - id: "Unicode-TOU"
+  # https://spdx.org/licenses/CNRI-Python.html
+  - id: "CNRI-Python"
     categories:
-      - "proprietary-free"
+      - "permissive"
+      - "property:include-in-notice-file"
 
-  # https://www.highcharts.com/license
-  - id: "LicenseRef-highsoft-standard-license-agreement"
+  - id: "COMMERCIAL"
     categories:
       - "commercial"
 
-  # https://spdx.org/licenses/Spencer-86.html
-  - id: "Spencer-86"
+  # https://spdx.org/licenses/CPL-1.0.html
+  - id: "CPL-1.0"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  # https://spdx.org/licenses/CUA-OPL-1.0.html
+  - id: "CUA-OPL-1.0"
+    categories:
+      - "copyleft-file-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  - id: "Classpath-exception-2.0"
+    categories:
+      - "property:AutoConf-or-other-exception"
+      - "property:include-in-notice-file"
+
+  - id: "Cryptogams"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
 
-  # https://spdx.org/licenses/Spencer-94.html
-  - id: "Spencer-94"
+  - id: "DEC-Unknown-License"
+    categories:
+      - "commercial"
+
+  - id: "DOC"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
 
-  - id: "redistribution-only-license"
+  - id: "Debian-SPI-style"
+    categories:
+      - "property:include-in-notice-file"
+      - "permissive"
+
+  - id: "EDL-1.0"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/EPL-1.0.html
+  - id: "EPL-1.0"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  # https://spdx.org/licenses/EPL-2.0.html
+  - id: "EPL-2.0"
+    categories:
+      - "copyleft-file-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  # https://spdx.org/licenses/EUPL-1.1.html
+  - id: "EUPL-1.1"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:network-clause"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/EUPL-1.2.html
+  - id: "EUPL-1.2"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:network-clause"
+      - "property:distribute-source-code"
+
+  - id: "Elastic-2.0"
+    categories:
+      - "source-available"
+      - "property:include-in-notice-file"
+
+  - id: "FSF"
+    categories:
+      - "permissive"
+
+  # https://spdx.org/licenses/FSFAP.html
+  - id: "FSFAP"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/FSFUL.html
+  - id: "FSFUL"
+    categories:
+      - "permissive"
+
+  # https://spdx.org/licenses/FSFULLR.html
+  - id: "FSFULLR"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/FSFULLRWD.html
+  - id: "FSFULLRWD"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "FTL"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "Font-exception-2.0"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  - id: "Free-SW"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "FreeImage"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+
+  - id: "Freeware"
     categories:
       - "proprietary-free"
 
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-redistribution-only-license"
+  - id: "GCC-exception"
     categories:
-      - "proprietary-free"
+      - "property:AutoConf-or-other-exception"
 
-  - id: "tso-license"
+  - id: "GCC-exception-2.0"
     categories:
-      - "permissive"
-      - "property:include-in-notice-file"
+      - "property:AutoConf-or-other-exception"
 
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-tso-license"
+  - id: "GCC-exception-3.1"
     categories:
-      - "permissive"
-      - "property:include-in-notice-file"
+      - "property:AutoConf-or-other-exception"
 
-  - id: "Non-profit"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-Non-profit"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "LicenseRef-GLib-manual"
+  # https://spdx.org/licenses/GFDL-1.3.html
+  - id: "GFDL"
     categories:
       - "copyleft-module-level"
       - "property:include-in-notice-file"
       - "property:unchecked"
 
-  - id: "LicenseRef-Red-Hat-Permissive-No-Warranty-No-Liability"
+  # https://spdx.org/licenses/GFDL-1.1.html
+  - id: "GFDL-1.1"
     categories:
-      - "permissive"
+      - "copyleft-module-level"
       - "property:include-in-notice-file"
+      - "property:unchecked"
 
-  - id: "LicenseRef-scancode-tim-janik-2003"
+  # https://spdx.org/licenses/GFDL-1.1.html
+  - id: "GFDL-1.1-only"
     categories:
-      - "permissive"
+      - "copyleft-module-level"
       - "property:include-in-notice-file"
+      - "property:unchecked"
 
-  # https://spdx.org/licenses/Unicode-DFS-2015.html
-  - id: "Unicode-DFS-2015"
+  # https://spdx.org/licenses/GFDL-1.1.html
+  - id: "GFDL-1.1-or-later"
     categories:
-      - "permissive"
+      - "copyleft-module-level"
       - "property:include-in-notice-file"
+      - "property:unchecked"
 
-  # https://spdx.org/licenses/Unicode-DFS-2016.html
-  - id: "Unicode-DFS-2016"
+  # https://spdx.org/licenses/GFDL-1.2.html
+  - id: "GFDL-1.2"
     categories:
-      - "permissive"
+      - "copyleft-module-level"
       - "property:include-in-notice-file"
+      - "property:unchecked"
 
-  - id: "Not-Free"
+  # https://spdx.org/licenses/GFDL-1.2.html
+  - id: "GFDL-1.2-only"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+      - "property:unchecked"
+
+  # https://spdx.org/licenses/GFDL-1.2.html
+  - id: "GFDL-1.2-or-later"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+      - "property:unchecked"
+
+  # https://spdx.org/licenses/GFDL-1.3.html
+  - id: "GFDL-1.3"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+      - "property:unchecked"
+
+  # https://spdx.org/licenses/GFDL-1.3.html
+  - id: "GFDL-1.3-only"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+      - "property:unchecked"
+
+  # https://spdx.org/licenses/GFDL-1.3.html
+  - id: "GFDL-1.3-or-later"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+      - "property:unchecked"
+
+  - id: "GNU-Manpages"
     categories:
       - "property:unclear-scanner-finding"
 
-  - id: "LicenseRef-verbatim-no-modifications"
+  - id: "GPL"
     categories:
-      - "proprietary-free"
+      - "property:unclear-scanner-finding"
 
-  - id: "LicenseRef-scancode-frontier-1.0"
+  # https://spdx.org/licenses/GPL-1.0-only.html
+  - id: "GPL-1.0"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/GPL-1.0-or-later.html
+  - id: "GPL-1.0+"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/GPL-1.0-only.html
+  - id: "GPL-1.0-only"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/GPL-1.0-or-later.html
+  - id: "GPL-1.0-or-later"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/GPL-1.0-or-later.html
+  # https://spdx.org/licenses/Autoconf-exception-generic.html
+  - id: "GPL-1.0-or-later WITH Autoconf-exception-generic"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-1.0-or-later.html
+  # https://spdx.org/licenses/Linux-syscall-note.html
+  - id: "GPL-1.0-or-later WITH Linux-syscall-note"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-2.0-only.html
+  - id: "GPL-2.0"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/GPL-2.0-only.html
+  # https://spdx.org/licenses/Classpath-exception-2.0.html
+  - id: "GPL-2.0 WITH Classpath-exception-2.0"
     categories:
       - "copyleft-module-level"
       - "property:include-in-notice-file"
       - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
 
-  - id: "LicenseRef-bsd-original-uc-1986"
+  # https://spdx.org/licenses/GPL-2.0-only.html
+  # https://spdx.org/licenses/Linux-syscall-note.html
+  - id: "GPL-2.0 WITH Linux-syscall-note"
     categories:
-      - "permissive"
+      - "copyleft-strong"
       - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
 
-  - id: "LicenseRef-naist-2003"
+  # https://spdx.org/licenses/GPL-2.0-only.html
+  # https://spdx.org/licenses/OpenJDK-assembly-exception-1.0.html
+  - id: "GPL-2.0 WITH OpenJDK-assembly-exception-1.0"
     categories:
-      - "permissive"
+      - "copyleft-strong"
       - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-2.0-or-later.html
+  - id: "GPL-2.0+"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/GPL-2.0-only.html
+  - id: "GPL-2.0-only"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/GPL-2.0-only.html
+  # https://spdx.org/licenses/Classpath-exception-2.0.html
+  - id: "GPL-2.0-only WITH Classpath-exception-2.0"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-2.0-only.html
+  # https://spdx.org/licenses/Font-exception-2.0.html
+  - id: "GPL-2.0-only WITH Font-exception-2.0"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  - id: "GPL-2.0-only WITH GCC-exception-2.0"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-2.0-only.html
+  # https://scancode-licensedb.aboutcode.org/mysql-linking-exception-2018.html
+  - id: "GPL-2.0-only WITH LicenseRef-scancode-mysql-linking-exception-2018"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  - id: "GPL-2.0-only WITH Linux-syscall-note"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-2.0-only.html
+  # https://spdx.org/licenses/Universal-FOSS-exception-1.0.html
+  - id: "GPL-2.0-only WITH Universal-FOSS-exception-1.0"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-2.0-or-later.html
+  - id: "GPL-2.0-or-later"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/GPL-2.0-or-later.html
+  # https://spdx.org/licenses/Autoconf-exception-2.0.html
+  - id: "GPL-2.0-or-later WITH Autoconf-exception-2.0"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-2.0-or-later.html
+  # https://spdx.org/licenses/Autoconf-exception-generic.html
+  - id: "GPL-2.0-or-later WITH Autoconf-exception-generic"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-2.0-or-later.html
+  # https://spdx.org/licenses/Bison-exception-2.2.html
+  - id: "GPL-2.0-or-later WITH Bison-exception-2.2"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-2.0-or-later.html
+  # https://spdx.org/licenses/Classpath-exception-2.0.html
+  - id: "GPL-2.0-or-later WITH Classpath-exception-2.0"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  - id: "GPL-2.0-or-later WITH GCC-exception-2.0"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-2.0-or-later.html
+  # https://spdx.org/licenses/Libtool-exception.html
+  - id: "GPL-2.0-or-later WITH Libtool-exception"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-2.0-or-later.html
+  # https://spdx.org/licenses/Linux-syscall-note.html
+  - id: "GPL-2.0-or-later WITH Linux-syscall-note"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-2.0-or-later.html
+  # https://spdx.org/licenses/eCos-exception-2.0.html
+  - id: "GPL-2.0-or-later WITH eCos-exception-2.0"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
 
   # Duplicate of the previous classification due to tooling requirements.
-  - id: "naist-2003"
+  - id: "GPL-2.0-or-later-WITH-Autoconf-exception-2.0"
     categories:
-      - "permissive"
+      - "copyleft-strong"
       - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
 
-  # https://tldp.org/COPYRIGHT.html
-  - id: "LDPL"
+  - id: "GPL-2.0-or-later-with-autoconf-macro-exception"
     categories:
-      - "copyleft-file-level"
+      - "copyleft-strong"
       - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
 
-  # https://tldp.org/COPYRIGHT.html
-  - id: "LicenseRef-LDPL"
+  # https://spdx.org/licenses/GPL-2.0-or-later.html
+  # https://spdx.org/licenses/Bison-exception-2.2.html
+  - id: "GPL-2.0-or-later-with-bison-exception-2.0"
     categories:
-      - "copyleft-file-level"
+      - "copyleft-strong"
       - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
 
-  - id: "LicenseRef-agafari-font-non-commercial"
+  # https://spdx.org/licenses/GPL-2.0-only.html
+  # https://spdx.org/licenses/GCC-exception-2.0.html
+  - id: "GPL-2.0-with-GCC-exception"
     categories:
-      - "free-restricted"
-      - "property:non-commercial"
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
 
-  - id: "RedHat"
+  - id: "GPL-2.1sic"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  # https://spdx.org/licenses/GPL-3.0-only.html
+  - id: "GPL-3.0"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  # https://spdx.org/licenses/GPL-3.0-or-later.html
+  - id: "GPL-3.0+"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  - id: "GPL-3.0-linking-source-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-3.0-only.html
+  - id: "GPL-3.0-only"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  # https://spdx.org/licenses/GPL-3.0-only.html
+  # https://spdx.org/licenses/Autoconf-exception-3.0.html
+  - id: "GPL-3.0-only WITH Autoconf-exception-3.0"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-3.0-only.html
+  # https://spdx.org/licenses/GCC-exception-3.1.html
+  - id: "GPL-3.0-only WITH GCC-exception-3.1"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-3.0-or-later.html
+  - id: "GPL-3.0-or-later"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  # https://spdx.org/licenses/GPL-3.0-or-later.html
+  # https://spdx.org/licenses/Autoconf-exception-2.0.html
+  - id: "GPL-3.0-or-later WITH Autoconf-exception-2.0"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-3.0-or-later.html
+  # https://spdx.org/licenses/Autoconf-exception-3.0.html
+  - id: "GPL-3.0-or-later WITH Autoconf-exception-3.0"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-3.0-or-later.html
+  # https://spdx.org/licenses/Autoconf-exception-generic.html
+  - id: "GPL-3.0-or-later WITH Autoconf-exception-generic"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-3.0-or-later.html
+  # https://spdx.org/licenses/Bison-exception-2.2.html
+  - id: "GPL-3.0-or-later WITH Bison-exception-2.2"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-3.0-or-later.html
+  # https://spdx.org/licenses/GCC-exception-3.1.html
+  - id: "GPL-3.0-or-later WITH GCC-exception-3.1"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-3.0-or-later.html
+  # https://spdx.org/licenses/Libtool-exception.html
+  - id: "GPL-3.0-or-later WITH Libtool-exception"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-3.0-or-later.html
+  # https://scancode-licensedb.aboutcode.org/autoconf-macro-exception.html
+  - id: "GPL-3.0-or-later WITH LicenseRef-scancode-autoconf-macro-exception"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-3.0-or-later.html
+  # https://scancode-licensedb.aboutcode.org/autoconf-simple-exception.html
+  - id: "GPL-3.0-or-later WITH LicenseRef-scancode-autoconf-simple-exception"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-3.0-or-later.html
+  # https://scancode-licensedb.aboutcode.org/tex-exception.html
+  - id: "GPL-3.0-or-later WITH LicenseRef-scancode-tex-exception"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-3.0-or-later.html
+  # https://spdx.org/licenses/Bison-exception-2.2.html
+  - id: "GPL-3.0-or-later-WITH-Bison-exception-2.2"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-3.0-or-later.html
+  # http://git.openembedded.org/openembedded-core/tree/meta/files/common-licenses/GPL-2.0-with-autoconf-exception
+  - id: "GPL-3.0-or-later-with-Autoconf-macro-exception"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  - id: "GPL-exception"
+    categories:
+      - "irrelevant"
+
+  - id: "GPL-possibility"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "HP-Compaq"
+    categories:
+      - "irrelevant"
+
+  - id: "HP-DEC"
     categories:
       - "commercial"
 
-  - id: "U-Mich-style"
+  - id: "HP-possibility"
     categories:
-      - "permissive"
+      - "property:unclear-scanner-finding"
 
-  - id: "U-Michigan"
-    categories:
-      - "permissive"
-
-  - id: "LicenseRef-U-Michigan"
-    categories:
-      - "permissive"
-
-  # https://spdx.org/licenses/OLDAP-2.8.html
-  - id: "LicenseRef-OLDAP"
+  # https://spdx.org/licenses/HPND.html
+  - id: "HPND"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
 
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "OLDAP"
+  # https://spdx.org/licenses/HPND-sell-variant.html
+  - id: "HPND-sell-variant"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
 
-  # https://scancode-licensedb.aboutcode.org/wordnet.html
-  - id: "WordNet-3.0"
+  - id: "IBM-dhcp"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
 
-  # https://scancode-licensedb.aboutcode.org/wordnet.html
-  - id: "LicenseRef-WordNet-3.0"
+  # https://spdx.org/licenses/IBM-pibs.html
+  - id: "IBM-pibs"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
 
-  - id: "NRL"
+  - id: "IBM-possibility"
     categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:advertising-clause"
+      - "property:unclear-scanner-finding"
 
-  - id: "USC"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-USC"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-Unicode"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "Unicode"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://scancode-licensedb.aboutcode.org/ietf.html
-  - id: "LicenseRef-IETF"
+  # https://spdx.org/licenses/ICU.html
+  - id: "ICU"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
@@ -3764,594 +1657,59 @@ categorizations:
       - "permissive"
       - "property:include-in-notice-file"
 
-  # http://publib.boulder.ibm.com/tividd/td/TWS/SC32-1267-00/en_US/HTML/eqqm1mst68.htm
-  - id: "SSLeay"
+  # https://spdx.org/licenses/IJG.html
+  - id: "IJG"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
-      - "property:advertising-clause"
 
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-SSLeay"
+  - id: "IJG-possibility"
     categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:advertising-clause"
-
-  # https://web.cs.ucdavis.edu/~rogaway/ocb/license1.pdf
-  - id: "LicenseRef-scancode-ocb-open-source-2013"
-    categories:
-      - "permissive"
-
-  # https://spdx.org/licenses/libselinux-1.0.html
-  - id: "libselinux-1.0"
-    categories:
-      - "public-domain"
-
-  - id: "LicenseRef-IBM-US-Government-Restriction"
-    categories:
-      - "proprietary-free"
+      - "property:unclear-scanner-finding"
 
   - id: "IOS"
     categories:
       - "proprietary-free"
       - "property:include-in-notice-file"
 
-  - id: "LicenseRef-IOS"
+  - id: "IPA"
     categories:
-      - "proprietary-free"
+      - "copyleft-module-level"
       - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/IPL-1.0.html
+  - id: "IPL-1.0"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
 
   - id: "IPTC"
     categories:
       - "proprietary-free"
       - "property:include-in-notice-file"
 
-  - id: "LicenseRef-W3C-IP"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "W3C-IP"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "LicenseRef-brian-gladman-3-clause"
+  # https://spdx.org/licenses/ISC.html
+  - id: "ISC"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
 
-  - id: "mif-exception"
+  - id: "ISC-possibility"
     categories:
-      - "property:AutoConf-or-other-exception"
+      - "permissive"
 
-  - id: "LicenseRef-mif-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "CCPL"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "COMMERCIAL"
-    categories:
-      - "commercial"
-
-  - id: "LicenseRef-COMMERCIAL"
-    categories:
-      - "commercial"
-
-  - id: "DEC-Unknown-License"
-    categories:
-      - "commercial"
-
-  - id: "LicenseRef-DEC-Unknown-License"
-    categories:
-      - "commercial"
-
-  - id: "HP-DEC"
-    categories:
-      - "commercial"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-HP-DEC"
-    categories:
-      - "commercial"
-
-  - id: "HP-Compaq"
-    categories:
-      - "irrelevant"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-HP-Compaq"
-    categories:
-      - "irrelevant"
-
-  - id: "XFree86"
+  - id: "ISC-style"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
 
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-XFree86"
+  # https://spdx.org/licenses/Info-ZIP.html
+  - id: "Info-ZIP"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
-
-  - id: "Intel-WLAN"
-    categories:
-      - "irrelevant"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-Intel-WLAN"
-    categories:
-      - "irrelevant"
-
-  - id: "Intel-Binary"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-      - "property:unchecked"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-Intel-Binary"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-      - "property:unchecked"
-
-  - id: "GPL-2.1sic"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  # https://scancode-licensedb.aboutcode.org/ms-lpl.html
-  - id: "MS-LPL"
-    categories:
-      - "free-restricted"
-      - "property:include-in-notice-file"
-      - "property:patent-clause"
-      - "property:unchecked"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-MS-LPL"
-    categories:
-      - "free-restricted"
-      - "property:include-in-notice-file"
-      - "property:patent-clause"
-      - "property:unchecked"
-
-  - id: "Motorola"
-    categories:
-      - "commercial"
-
-  - id: "Not-for-sale"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  # https://raw.githubusercontent.com/copyleft-next/copyleft-next/master/Releases/copyleft-next-0.3.1
-  - id: "copyleft-next-0.3.1"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:unchecked"
-
-  - id: "LicenseRef-bsd-dpt"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-gpl-2.0-adaptec"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-michigan-disclaimer"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "RHeCos-1.1"
-    categories:
-      - "copyleft-file-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:unchecked"
-
-  - id: "LicenseRef-synopsys-attribution"
-    categories:
-      - "free-restricted"
-      - "property:include-in-notice-file"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "synopsys-attribution"
-    categories:
-      - "free-restricted"
-      - "property:include-in-notice-file"
-
-  - id: "OSF-style"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "Keyspan-FW"
-    categories:
-      - "proprietary-free"
-      - "property:unchecked"
-
-  - id: "Nvidia-EULA-b"
-    categories:
-      - "commercial"
-
-  - id: "LicenseRef-Nvidia-EULA-b"
-    categories:
-      - "commercial"
-
-  - id: "LicenseRef-Xceive-license"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-broadcom-linux-firmware"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-cavium-linux-firmware"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-marvell-firmware"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-moxa-linux-firmware"
-    categories:
-      - "proprietary-free"
-
-  - id: "LicenseRef-qca-technology"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-stmicroelectronics-linux-firmware"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-
-  - id: "SSH-OpenSSH"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-bsd-credit"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "SISSL"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  - id: "ZPL"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "LicenseRef-ZPL"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-tested-software"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-Linux-HOWTO"
-    categories:
-      - "copyleft-file-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:unchecked"
-
-  - id: "eCos-2.0"
-    categories:
-      - "copyleft-file-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:unchecked"
-
-  - id: "eCos-exception-2.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-eCos-exception-2.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-freebsd-boot"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-Mediatek"
-    categories:
-      - "commercial"
-
-  - id: "LicenseRef-scancode-netronome-firmware"
-    categories:
-      - "proprietary-free"
-
-  - id: "LicenseRef-netronome-firmware"
-    categories:
-      - "proprietary-free"
-
-  - id: "LicenseRef-scancode-newlib-subdirectory"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  - id: "LicenseRef-scancode-binary-linux-firmware-patent"
-    categories:
-      - "proprietary-free"
-
-  - id: "LicenseRef-GPL-2.0-or-later-with-strongswan-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-amd-linux-firmware-export"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-motorola"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-gnu-emacs-gpl-1988"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-
-  - id: "LicenseRef-GPL-2.0-or-later-with-shtool-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-Bellcore"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # Proprietary recipes for Yocto.
-  - id: "LicenseRef-CLOSED"
-    categories:
-      - "irrelevant"
-
-  - id: "LicenseRef-scancode-ms-net-library-2018-11"
-    categories:
-      - "proprietary-free"
-
-  - id: "LicenseRef-scancode-ms-net-library"
-    categories:
-      - "proprietary-free"
-
-  - id: "LicenseRef-scancode-ms-asp-net-web-optimization-framework"
-    categories:
-      - "proprietary-free"
-
-  - id: "LicenseRef-scancode-unknown-license-reference"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "LicenseRef-scancode-free-unknown"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "LicenseRef-scancode-unknown"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "LicenseRef-scancode-bytemark"
-    categories:
-      - "permissive"
-
-  - id: "LicenseRef-scancode-generic-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-scancode-mysql-linking-exception-2018"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-scancode-mit-addition"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-ms-patent-promise"
-    categories:
-      - "irrelevant"
-
-  - id: "FTL"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "EDL-1.0"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-openpub"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-reportbug"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://opensource.apple.com/source/bzip2/bzip2-16/bzip2/manual.html
-  - id: "LicenseRef-bzip2-1.0.4"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/Apache-2.0.html
-  # https://spdx.org/licenses/LLVM-exception.html
-  - id: "Apache-2.0 WITH LLVM-exception"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:patent-clause"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-Firmware-imx-sdma-firmware"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-nxp-firmware-patent"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-m-plus"
-    categories:
-      - "permissive"
-
-  - id: "LicenseRef-scancode-google-patent-license-golang"
-    categories:
-      - "permissive"
-
-  - id: "LicenseRef-scancode-facebook-patent-rights-2"
-    categories:
-      - "permissive"
-      - "property:patent-clause"
-
-  - id: "LicenseRef-scancode-arm-llvm-sga"
-    categories:
-      - "permissive"
-      - "property:patent-clause"
-
-  - id: "NetCDF"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "OGC-1.0"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "OGL-UK-3.0"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/Zed.html
-  - id: "Zed"
-    categories:
-      - "free-restricted"
-
-  - id: "IPA"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-
-  - id: "Elastic-2.0"
-    categories:
-      - "source-available"
-      - "property:include-in-notice-file"
-
-  - id: "Bitstream-Vera"
-    categories:
-      - "free-restricted"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-cncf-individual-cla-1.0"
-    categories:
-      - "irrelevant"
-
-  - id: "LicenseRef-scancode-apple-attribution-1997"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://www.w3.org/copyright/test-suite-license-2008/
-  - id: "LicenseRef-scancode-w3c-test-suite"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-html5"
-    categories:
-      - "permissive"
-
-  # https://spdx.org/licenses/mplus.html
-  - id: "mplus"
-    categories:
-      - "permissive"
-
-  # https://spdx.org/licenses/ODC-By-1.0.html
-  - id: "ODC-By-1.0"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-ecma-no-patent"
-    categories:
-      - "proprietary-free"
-
-  - id: "LicenseRef-scancode-pngsuite"
-    categories:
-      - "permissive"
-
-  # https://www.ogc.org/about-ogc/policies/document-notice/
-  - id: "LicenseRef-scancode-ogc-document-2020"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-eclipse-sua-2005"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  - id: "LicenseRef-scancode-afpl-9.0"
-    categories:
-      - "free-restricted"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:non-commercial"
-
-  - id: "LicenseRef-scancode-carnegie-mellon-contributors"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  - id: "LicenseRef-scancode-inner-net-2.0"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "property:advertising-clause"
 
   # https://spdx.org/licenses/Inner-Net-2.0.html
   - id: "Inner-Net-2.0"
@@ -4359,32 +1717,133 @@ categorizations:
       - "permissive"
       - "property:include-in-notice-file"
 
-  - id: "LicenseRef-scancode-pcre"
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "InnerNet-2.00"
+    categories:
+      - "property:unchecked"
+
+  # https://spdx.org/licenses/Intel.html
+  - id: "Intel"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
-      - "property:mark-modifications"
 
-  - id: "LicenseRef-LGPL-2.1-or-later-with-linking-exception"
+  - id: "Intel-Binary"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+      - "property:unchecked"
+
+  - id: "Intel-WLAN"
+    categories:
+      - "irrelevant"
+
+  # https://spdx.org/licenses/JPNIC.html
+  - id: "JPNIC"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/JSON.html
+  - id: "JSON"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "Keyspan-FW"
+    categories:
+      - "proprietary-free"
+      - "property:unchecked"
+
+  # https://tldp.org/COPYRIGHT.html
+  - id: "LDPL"
+    categories:
+      - "copyleft-file-level"
+      - "property:include-in-notice-file"
+
+  - id: "LGPL"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  # https://spdx.org/licenses/LGPL-2.0-only.html
+  - id: "LGPL-2.0"
+    categories:
+      - "copyleft-LGPL"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/LGPL-2.0-only.html
+  - id: "LGPL-2.0-only"
+    categories:
+      - "copyleft-LGPL"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/LGPL-2.0-or-later.html
+  - id: "LGPL-2.0-or-later"
+    categories:
+      - "copyleft-LGPL"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/LGPL-2.0-or-later.html
+  # https://spdx.org/licenses/Linux-syscall-note.html
+  - id: "LGPL-2.0-or-later WITH Linux-syscall-note"
     categories:
       - "copyleft-LGPL"
       - "property:include-in-notice-file"
       - "property:distribute-source-code"
       - "property:AutoConf-or-other-exception"
 
-  - id: "LicenseRef-scancode-ibm-dhcp"
+  # https://spdx.org/licenses/LGPL-2.0-or-later.html
+  # https://spdx.org/licenses/OCaml-LGPL-linking-exception.html
+  - id: "LGPL-2.0-or-later WITH OCaml-LGPL-linking-exception"
     categories:
-      - "permissive"
+      - "copyleft-LGPL"
       - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
 
-  # https://spdx.org/licenses/GFDL-1.3.html
-  - id: "GFDL-1.3-only"
+  # https://spdx.org/licenses/LGPL-2.1-only.html
+  - id: "LGPL-2.1"
     categories:
-      - "copyleft-module-level"
+      - "copyleft-LGPL"
       - "property:include-in-notice-file"
-      - "property:unchecked"
+      - "property:distribute-source-code"
 
-  - id: "LicenseRef-LGPL-2.1-or-later-with-unlimited-linking-exception"
+  # https://spdx.org/licenses/LGPL-2.1-only.html
+  # https://spdx.org/licenses/Linux-syscall-note.html
+  - id: "LGPL-2.1 WITH Linux-syscall-note"
+    categories:
+      - "copyleft-LGPL"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/LGPL-2.1-only.html
+  - id: "LGPL-2.1-only"
+    categories:
+      - "copyleft-LGPL"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/LGPL-2.1-only.html
+  # https://spdx.org/licenses/OCaml-LGPL-linking-exception.html
+  - id: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+    categories:
+      - "copyleft-LGPL"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/LGPL-2.1-or-later.html
+  - id: "LGPL-2.1-or-later"
+    categories:
+      - "copyleft-LGPL"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  - id: "LGPL-2.1-or-later WITH GCC-exception-2.0"
     categories:
       - "copyleft-LGPL"
       - "property:include-in-notice-file"
@@ -4400,21 +1859,9 @@ categorizations:
       - "property:distribute-source-code"
       - "property:AutoConf-or-other-exception"
 
-  - id: "LicenseRef-scancode-unlimited-link-exception-lgpl"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "LicenseRef-scancode-bsd-new-tcpdump"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-
-  # https://spdx.org/licenses/LGPL-2.1-only.html
-  # https://spdx.org/licenses/OCaml-LGPL-linking-exception.html
-  - id: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
+  # https://spdx.org/licenses/LGPL-2.1-or-later.html
+  # https://spdx.org/licenses/Linux-syscall-note.html
+  - id: "LGPL-2.1-or-later WITH Linux-syscall-note"
     categories:
       - "copyleft-LGPL"
       - "property:include-in-notice-file"
@@ -4430,16 +1877,342 @@ categorizations:
       - "property:distribute-source-code"
       - "property:AutoConf-or-other-exception"
 
-  - id: "LicenseRef-scancode-x11-stanford"
+  # https://spdx.org/licenses/LGPL-3.0-only.html
+  - id: "LGPL-3.0"
+    categories:
+      - "copyleft-LGPL"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  # https://spdx.org/licenses/LGPL-3.0-only.html
+  - id: "LGPL-3.0-only"
+    categories:
+      - "copyleft-LGPL"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  # https://spdx.org/licenses/LGPL-3.0-or-later.html
+  - id: "LGPL-3.0-or-later"
+    categories:
+      - "copyleft-LGPL"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  # https://spdx.org/licenses/LGPL-3.0-or-later.html
+  # https://spdx.org/licenses/openvpn-openssl-exception.html
+  - id: "LGPL-3.0-or-later WITH openvpn-openssl-exception"
+    categories:
+      - "copyleft-LGPL"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LGPL-possibility"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  # https://spdx.org/licenses/LLVM-exception.html
+  - id: "LLVM-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/LPL-1.02.html
+  - id: "LPL-1.02"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  # https://spdx.org/licenses/LPPL-1.0.html
+  - id: "LPPL-1.0"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/LPPL-1.0.html
+  - id: "LPPL-1.0+"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/LPPL-1.0.html
+  - id: "LPPL-1.0-or-later"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/LPPL-1.2.html
+  - id: "LPPL-1.2"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/LPPL-1.2.html
+  - id: "LPPL-1.2+"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/LPPL-1.2.html
+  - id: "LPPL-1.2-or-later"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  - id: "LPPL-1.3a"
+    categories:
+      - "property:unchecked"
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/LPPL-1.3c.html
+  - id: "LPPL-1.3c"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/Latex2e.html
+  - id: "Latex2e"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+      - "property:unchecked"
+
+  # https://spdx.org/licenses/Libpng.html
+  - id: "Libpng"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
 
-  - id: "BSD-3-Clause-No-Nuclear-License"
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "Libtool-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-389-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-Apache"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-Apple.Sample"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-Autoconf-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-Autoconf-exception-3.0"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-BSD"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-BSD-1-Clause-No-Notice-Requirement"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-BSD-1-Clause-No-Notice-Requirements"
+    categories:
+      - "permissive"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-BSD-2"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
-      - "property:nuclear-restriction"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-BSD-4-Clause-NetBSD"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-BSD-possibility"
+    categories:
+      - "permissive"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-BSD-style"
+    categories:
+      - "permissive"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-BSL-style"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-Bellcore"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-Bison-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-Bison-exception-2.2"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-Bootloader-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  # Proprietary recipes for Yocto.
+  - id: "LicenseRef-CLOSED"
+    categories:
+      - "irrelevant"
+
+  - id: "LicenseRef-CMU"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-CMU-style"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-COMMERCIAL"
+    categories:
+      - "commercial"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-Classpath-exception-2.0"
+    categories:
+      - "property:AutoConf-or-other-exception"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-Cryptogams"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-DEC-Unknown-License"
+    categories:
+      - "commercial"
+
+  - id: "LicenseRef-Debian-SPI-style"
+    categories:
+      - "property:include-in-notice-file"
+      - "permissive"
+
+  # https://www.eclipse.org/legal/tck.php
+  - id: "LicenseRef-EFTCK-1.0"
+    categories:
+      - "free-restricted"
+      - "property:include-in-notice-file"
+      - "property:no-modifications"
+  - id: "LicenseRef-Elfutils-Exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-FSF"
+    categories:
+      - "permissive"
+
+  # https://scancode-licensedb.aboutcode.org/fsf-unlimited-no-warranty.html
+  - id: "LicenseRef-FSF-Unlimited-No-Warranty"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-Firmware-imx-sdma-firmware"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-Font-exception-2.0"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-GCC-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-GCC-exception-2.0"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-GCC-exception-3.1"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-GFDL"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+      - "property:unchecked"
+
+  - id: "LicenseRef-GLib-manual"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+      - "property:unchecked"
+
+  - id: "LicenseRef-GPL"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  # https://spdx.org/licenses/GPL-2.0-or-later.html
+  - id: "LicenseRef-GPL-2.0-or-later-with-TeX-exception"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-2.0-or-later.html
+  - id: "LicenseRef-GPL-2.0-or-later-with-autoconf-macro-exception"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-2.0-or-later.html
+  # https://spdx.org/licenses/Bison-exception-2.2.html
+  - id: "LicenseRef-GPL-2.0-or-later-with-bison-exception-2.0"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
 
   - id: "LicenseRef-GPL-2.0-or-later-with-guile-exception-2.0"
     categories:
@@ -4448,13 +2221,463 @@ categorizations:
       - "property:distribute-source-code"
       - "property:AutoConf-or-other-exception"
 
-  - id: "LicenseRef-scancode-gary-s-brown"
+  # https://spdx.org/licenses/GPL-2.0-or-later.html
+  # https://github.com/gpg/libgpg-error/blob/220a427b4f997ef6af1b2d4e82ef1dc96e0cd6ff/lang/cl/mkerrcodes.awk
+  - id: "LicenseRef-GPL-2.0-or-later-with-mkerrcodes.awk-exception"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-GPL-2.0-or-later-with-shtool-exception"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-GPL-2.0-or-later-with-strongswan-exception"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-2.0-or-later.html
+  # https://spdx.org/licenses/openvpn-openssl-exception.html
+  - id: "LicenseRef-GPL-2.0-with-OpenSSL-exception"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-2.0-or-later.html
+  # https://spdx.org/licenses/openvpn-openssl-exception.html
+  - id: "LicenseRef-GPL-2.0-with-openssl-exception"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-3.0-or-later.html
+  - id: "LicenseRef-GPL-3.0-or-later-with-Autoconf-macro-exception"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/GPL-3.0-or-later.html
+  - id: "LicenseRef-GPL-3.0-or-later-with-TeX-exception"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-HP-Compaq"
+    categories:
+      - "irrelevant"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-HP-DEC"
+    categories:
+      - "commercial"
+
+  - id: "LicenseRef-IBM-US-Government-Restriction"
+    categories:
+      - "proprietary-free"
+
+  - id: "LicenseRef-IBM-dhcp"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://scancode-licensedb.aboutcode.org/ietf.html
+  - id: "LicenseRef-IETF"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-IOS"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-InnerNet-2.00"
+    categories:
+      - "property:unchecked"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-Intel-Binary"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+      - "property:unchecked"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-Intel-WLAN"
+    categories:
+      - "irrelevant"
+
+  # https://tldp.org/COPYRIGHT.html
+  - id: "LicenseRef-LDPL"
+    categories:
+      - "copyleft-file-level"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-LGPL"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "LicenseRef-LGPL-2.1-or-later-with-linking-exception"
+    categories:
+      - "copyleft-LGPL"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-LGPL-2.1-or-later-with-unlimited-linking-exception"
+    categories:
+      - "copyleft-LGPL"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-Libtool-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  # This is needed for the license to (not) be picked correctly for notice generation.
+  - id: "LicenseRef-LicenseRef-Permissive-no-warranty"
     categories:
       - "permissive"
 
-  - id: "LicenseRef-sflow-license"
+  - id: "LicenseRef-Linux-HOWTO"
+    categories:
+      - "copyleft-file-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:unchecked"
+
+  - id: "LicenseRef-Linux-syscall-note"
+    categories:
+      - "property:AutoConf-or-other-exception"
+      - "copyleft-strong"
+      - "property:distribute-source-code"
+
+  - id: "LicenseRef-MIT-CMU-style"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-MIT-old-style-no-adv"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-MIT-old-style-with-legal-disclaimer"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-MIT-possibility"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-MIT-style"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-MPL"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-MS-LPL"
+    categories:
+      - "free-restricted"
+      - "property:include-in-notice-file"
+      - "property:patent-clause"
+      - "property:unchecked"
+
+  - id: "LicenseRef-Mediatek"
+    categories:
+      - "commercial"
+
+  - id: "LicenseRef-NOT-public-domain"
+    categories:
+      - "irrelevant"
+
+  - id: "LicenseRef-NewBSD"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-Non-profit"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-NotreDame-style"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-Nvidia-EULA-b"
+    categories:
+      - "commercial"
+
+  # https://spdx.org/licenses/OLDAP-2.8.html
+  - id: "LicenseRef-OLDAP"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://www.openldap.org/software/release/license.html
+  - id: "LicenseRef-OpenLDAP"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-OpenSSL-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  # http://pcre.sourceforge.net/license.txt
+  - id: "LicenseRef-PCRE"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:unchecked"
+
+  - id: "LicenseRef-PD"
+    categories:
+      - "public-domain"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-Patent-ref"
+    categories:
+      - "irrelevant"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-Perl-possibility"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "LicenseRef-Permissive-attribution"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-Permissive-no-warranty"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-Public-domain"
+    categories:
+      - "public-domain"
+
+  - id: "LicenseRef-Public-domain-ref"
+    categories:
+      - "public-domain"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-Public-domainC"
+    categories:
+      - "public-domain"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-Python"
+    categories:
+      - "property:include-in-notice-file"
+      - "permissive"
+
+  - id: "LicenseRef-Python-2.2"
+    categories:
+      - "property:include-in-notice-file"
+      - "permissive"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-RSA-Cryptoki"
+    categories:
+      - "permissive"
+      - "property:advertising-clause"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-Rdisc"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-Red-Hat-Permissive-No-Warranty-No-Liability"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-SSLeay"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:advertising-clause"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-Same-license-as"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "LicenseRef-Scanner-WebM"
+    categories:
+      - "property:include-in-notice-file"
+      - "permissive"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-See-URL"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-See-doc.OTHER"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-See-file"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-See-file.COPYING"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-See-file.LICENSE"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-See-file.README"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "LicenseRef-SunPro"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://github.com/joelagnel/meta-ti/blob/fd86d69fde9203136bd2f22d4f5e7c810f44c42d/licenses/TI-TFL
+  - id: "LicenseRef-TI-TFL"
+    categories:
+      - "property:include-in-notice-file"
+      - "proprietary-free"
+      - "property:unchecked"
+
+  - id: "LicenseRef-TeX-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-U-Michigan"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-USC"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-Unicode"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-W3C-IP"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "LicenseRef-W3C-copyright-documents-19990405"
+    categories:
+      - "property:unchecked"
+      - "free-restricted"
+      - "property:include-in-notice-file"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-W3C-possibility"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/W3C.html
+  - id: "LicenseRef-W3C-style"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-WebM"
+    categories:
+      - "property:include-in-notice-file"
+      - "permissive"
+
+  - id: "LicenseRef-Windows-binary-build-Python"
+    categories:
+      - "free-restricted"
+      - "property:include-in-notice-file"
+
+  # https://scancode-licensedb.aboutcode.org/wordnet.html
+  - id: "LicenseRef-WordNet-3.0"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-X11-possibility"
+    categories:
+      - "permissive"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-X11-style"
+    categories:
+      - "permissive"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-XFree86"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-Xceive-license"
     categories:
       - "proprietary-free"
+      - "property:include-in-notice-file"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-ZPL"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-Zlib-possibility"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-agafari-font-non-commercial"
+    categories:
+      - "free-restricted"
+      - "property:non-commercial"
+
+  - id: "LicenseRef-amd-linux-firmware-export"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
 
   - id: "LicenseRef-benjamin-kowarsch"
     categories:
@@ -4462,17 +2685,1318 @@ categorizations:
       - "property:non-commercial"
       - "property:include-in-notice-file"
 
-  - id: "LicenseRef-Windows-binary-build-Python"
+  - id: "LicenseRef-brian-gladman-3-clause"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-broadcom-linux-firmware"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-bsd-credit"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-bsd-dpt"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-bsd-original-uc-1986"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-bzip2"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://opensource.apple.com/source/bzip2/bzip2-16/bzip2/manual.html
+  - id: "LicenseRef-bzip2-1.0.4"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-cavium-linux-firmware"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-eCos-exception-2.0"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-freebsd-boot"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://scancode-licensedb.aboutcode.org/fsf-unlimited-no-warranty.html
+  - id: "LicenseRef-fsf-unlimited-no-warranty"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-gary-s-brown"
+    categories:
+      - "permissive"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-gnu-javamail-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-gpl-2.0-adaptec"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/GPL-2.0-only.html
+  - id: "LicenseRef-gpl-2.0-or-later-with-ada-linking-exception"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  # https://www.highcharts.com/license
+  - id: "LicenseRef-highsoft-standard-license-agreement"
+    categories:
+      - "commercial"
+
+  - id: "LicenseRef-inner-net-2.0"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:advertising-clause"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-linking-exception"
+    categories:
+      - "property:unchecked"
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-marvell-firmware"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-michigan-disclaimer"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-mif-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-mit-no-advert-export-control"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-moxa-linux-firmware"
+    categories:
+      - "proprietary-free"
+
+  - id: "LicenseRef-naist-2003"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-netronome-firmware"
+    categories:
+      - "proprietary-free"
+
+  - id: "LicenseRef-nxp-firmware-patent"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-other-permissive"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-permissive-no-attribution-requirement"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-qca-technology"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-redistribution-only-license"
+    categories:
+      - "proprietary-free"
+
+  - id: "LicenseRef-scancode-ada-linking-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-scancode-afpl-9.0"
+    categories:
+      - "free-restricted"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:non-commercial"
+
+  - id: "LicenseRef-scancode-apple-attribution-1997"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-apple-sscl"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-scancode-arm-llvm-sga"
+    categories:
+      - "permissive"
+      - "property:patent-clause"
+
+  - id: "LicenseRef-scancode-autoconf-macro-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-autoconf-simple-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-autoconf-simple-exception-2.0"
+    categories:
+      - "property:AutoConf-or-other-exception"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-bakoma-fonts-1995"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-binary-linux-firmware-patent"
+    categories:
+      - "proprietary-free"
+
+  # https://scancode-licensedb.aboutcode.org/bison-exception-2.0.html
+  - id: "LicenseRef-scancode-bison-exception-2.0"
+    categories:
+      - "property:include-in-notice-file"
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-scancode-bitstream"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-bitzi-pd"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-scancode-blas-2017"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-boost-original"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-bsd-1988"
+    categories:
+      - "property:unchecked"
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://scancode-licensedb.aboutcode.org/bsd-3-clause-no-change.html
+  - id: "LicenseRef-scancode-bsd-3-clause-no-change"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://scancode-licensedb.aboutcode.org/bsd-axis-nomod.html
+  - id: "LicenseRef-scancode-bsd-axis-nomod"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-bsd-new-tcpdump"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-bsd-no-disclaimer"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-bsd-no-disclaimer-unmodified"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-bsd-original-uc-1986"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://github.com/nexB/scancode-licensedb/blob/main/docs/bsd-simplified-darwin.LICENSE
+  - id: "LicenseRef-scancode-bsd-simplified-darwin"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-bsd-unchanged"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-bsd-unmodified"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-bsd-x11"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-bsla"
+    categories:
+      - "property:advertising-clause"
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-bytemark"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-scancode-carnegie-mellon"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-carnegie-mellon-contributors"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://github.com/nexB/scancode-licensedb/blob/main/docs/cc-devnations-2.0.LICENSE
+  - id: "LicenseRef-scancode-cc-devnations-2.0"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  - id: "LicenseRef-scancode-cncf-individual-cla-1.0"
+    categories:
+      - "irrelevant"
+
+  - id: "LicenseRef-scancode-commercial-license"
+    categories:
+      - "commercial"
+
+  - id: "LicenseRef-scancode-cve-tou"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-dco-1.1"
+    categories:
+      - "irrelevant"
+
+  # https://scancode-licensedb.aboutcode.org/docbook.html
+  - id: "LicenseRef-scancode-docbook"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-eclipse-sua-2005"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  # https://scancode-licensedb.aboutcode.org/ecma-documentation.html
+  - id: "LicenseRef-scancode-ecma-documentation"
     categories:
       - "free-restricted"
       - "property:include-in-notice-file"
 
-  # https://www.python.org/download/releases/2.0.1/license/
-  - id: "Python-2.0.1"
+  - id: "LicenseRef-scancode-ecma-no-patent"
+    categories:
+      - "proprietary-free"
+
+  # https://scancode-licensedb.aboutcode.org/efsl-1.0.html
+  - id: "LicenseRef-scancode-efsl-1.0"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-ekioh"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-scancode-facebook-patent-rights-2"
+    categories:
+      - "permissive"
+      - "property:patent-clause"
+
+  - id: "LicenseRef-scancode-free-unknown"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "LicenseRef-scancode-freebsd-boot"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-freemarker"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-frontier-1.0"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  - id: "LicenseRef-scancode-fsf-notice"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-scancode-fsf-unlimited-no-warranty"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-gary-s-brown"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-scancode-generic-cla"
+    categories:
+      - "irrelevant"
+
+  - id: "LicenseRef-scancode-generic-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-scancode-generic-export-compliance"
+    categories:
+      - "irrelevant"
+
+  - id: "LicenseRef-scancode-gnu-emacs-gpl-1988"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  - id: "LicenseRef-scancode-google-patent-license-golang"
+    categories:
+      - "permissive"
+
+  # https://scancode-licensedb.aboutcode.org/h2-1.0.html
+  - id: "LicenseRef-scancode-h2-1.0"
+    categories:
+      - "copyleft-file-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  - id: "LicenseRef-scancode-html5"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-scancode-ibm-dhcp"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://scancode-licensedb.aboutcode.org/ietf.html
+  - id: "LicenseRef-scancode-ietf"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://scancode-licensedb.aboutcode.org/ietf-trust.html
+  - id: "LicenseRef-scancode-ietf-trust"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-indiana-extreme"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-inner-net-2.0"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:advertising-clause"
+
+  # https://github.com/nexB/scancode-licensedb/blob/main/docs/iptc-2006.LICENSE
+  - id: "LicenseRef-scancode-iptc-2006"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+
+  # https://scancode-licensedb.aboutcode.org/iso-8879.html
+  - id: "LicenseRef-scancode-iso-8879"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://scancode-licensedb.aboutcode.org/jdom.html
+  - id: "LicenseRef-scancode-jdom"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-jetty-ccla-1.1"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:patent-clause"
+
+  # https://scancode-licensedb.aboutcode.org/jpython-1.1.html
+  - id: "LicenseRef-scancode-jpython-1.1"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://github.com/nexB/scancode-licensedb/blob/main/docs/json-js-pd.LICENSE
+  - id: "LicenseRef-scancode-json-js-pd"
+    categories:
+      - "public-domain"
+
+  # https://github.com/nexB/scancode-licensedb/blob/main/docs/json-pd.LICENSE
+  - id: "LicenseRef-scancode-json-pd"
+    categories:
+      - "public-domain"
+
+  - id: "LicenseRef-scancode-jsr-107-jcache-spec-2013"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+
+  # https://scancode-licensedb.aboutcode.org/jython.html
+  - id: "LicenseRef-scancode-jython"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-ldap-sdk-free-use"
+    categories:
+      - "property:unchecked"
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-ldpgpl-1a"
+    categories:
+      - "copyleft-file-level"
+      - "property:include-in-notice-file"
+
+  # https://scancode-licensedb.aboutcode.org/libpbm.html
+  - id: "LicenseRef-scancode-libpbm"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-llnl"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-m-plus"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-scancode-minpack"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-mit-addition"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-mit-license-1998"
+    categories:
+      - "property:unchecked"
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-mit-modern"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-mit-nagy"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://github.com/nexB/scancode-toolkit/blob/ded56e9120f5fdfb9a1a0309130bb4305a66aacb/src/licensedcode/data/licenses/mit-no-advert-export-control.LICENSE
+  - id: "LicenseRef-scancode-mit-no-advert-export-control"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-mit-old-style"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-mit-old-style-no-advert"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://scancode-licensedb.aboutcode.org/mit-specification-disclaimer.html
+  - id: "LicenseRef-scancode-mit-specification-disclaimer"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-scancode-mit-synopsys"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-mit-veillard-variant"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-motorola"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-mozilla-gc"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-ms-asp-net-web-optimization-framework"
+    categories:
+      - "proprietary-free"
+
+  - id: "LicenseRef-scancode-ms-net-library"
+    categories:
+      - "proprietary-free"
+
+  - id: "LicenseRef-scancode-ms-net-library-2018-11"
+    categories:
+      - "proprietary-free"
+
+  - id: "LicenseRef-scancode-ms-patent-promise"
+    categories:
+      - "irrelevant"
+
+  # https://scancode-licensedb.aboutcode.org/ms-ws-routing-spec.html
+  - id: "LicenseRef-scancode-ms-ws-routing-spec"
+    categories:
+      - "permissive"
+
+  # https://github.com/nexB/scancode-licensedb/blob/main/docs/mx4j.LICENSE
+  - id: "LicenseRef-scancode-mx4j"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-mysql-floss-exception-2.0"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-scancode-mysql-linking-exception-2018"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-scancode-netronome-firmware"
+    categories:
+      - "proprietary-free"
+
+  - id: "LicenseRef-scancode-newlib-subdirectory"
+    categories:
+      - "copyleft-LGPL"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  - id: "LicenseRef-scancode-newton-king-cla"
+    categories:
+      - "unstated"
+
+  - id: "LicenseRef-scancode-nilsson-historical"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://scancode-licensedb.aboutcode.org/oasis-ws-security-spec.html
+  - id: "LicenseRef-scancode-oasis-ws-security-spec"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://web.cs.ucdavis.edu/~rogaway/ocb/license1.pdf
+  - id: "LicenseRef-scancode-ocb-open-source-2013"
+    categories:
+      - "permissive"
+
+  # https://github.com/nexB/scancode-toolkit/blob/ded56e9120f5fdfb9a1a0309130bb4305a66aacb/src/licensedcode/data/licenses/ogc.LICENSE
+  - id: "LicenseRef-scancode-ogc"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://www.ogc.org/about-ogc/policies/document-notice/
+  - id: "LicenseRef-scancode-ogc-document-2020"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-openjdk-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-openpub"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://scancode-licensedb.aboutcode.org/openssl.html
+  - id: "LicenseRef-scancode-openssl"
+    categories:
+      - "permissive"
+      - "property:advertising-clause"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/LGPL-3.0-or-later.html
+  # https://spdx.org/licenses/openvpn-openssl-exception.html
+  - id: "LicenseRef-scancode-openssl-exception-lgpl-3.0-plus"
+    categories:
+      - "copyleft-LGPL"
+      - "property:include-in-notice-file"
+      - "property:antitivo-clause"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+      - "property:AutoConf-or-other-exception"
+
+  # https://scancode-licensedb.aboutcode.org/oracle-openjdk-classpath-exception-2.0.html
+  - id: "LicenseRef-scancode-oracle-openjdk-classpath-exception-2.0"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-scancode-osf-1990"
+    categories:
+      - "property:unchecked"
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-other-copyleft"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+
+  # https://scancode-licensedb.aboutcode.org/other-permissive.html
+  - id: "LicenseRef-scancode-other-permissive"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-scancode-pcre"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
       - "property:mark-modifications"
+
+  # https://github.com/nexB/scancode-toolkit/blob/ded56e9120f5fdfb9a1a0309130bb4305a66aacb/src/licensedcode/data/licenses/philippe-de-muyter.LICENSE
+  - id: "LicenseRef-scancode-philippe-de-muyter"
+    categories:
+      - "permissive"
+
+  - id: "LicenseRef-scancode-pngsuite"
+    categories:
+      - "permissive"
+
+  # https://scancode-licensedb.aboutcode.org/proprietary-license.html
+  - id: "LicenseRef-scancode-proprietary-license"
+    categories:
+      - "commercial"
+
+  # https://scancode-licensedb.aboutcode.org/protobuf.html
+  - id: "LicenseRef-scancode-protobuf"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-psf-3.7.2"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-public-domain"
+    categories:
+      - "public-domain"
+
+  # https://scancode-licensedb.aboutcode.org/public-domain-disclaimer.html
+  - id: "LicenseRef-scancode-public-domain-disclaimer"
+    categories:
+      - "public-domain"
+
+  - id: "LicenseRef-scancode-python-cwi"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://github.com/nexB/scancode-toolkit/blob/ded56e9120f5fdfb9a1a0309130bb4305a66aacb/src/licensedcode/data/licenses/red-hat-attribution.LICENSE
+  - id: "LicenseRef-scancode-red-hat-attribution"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-reportbug"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-robert-hubley"
+    categories:
+      - "irrelevant"
+
+  - id: "LicenseRef-scancode-rsa-1990"
+    categories:
+      - "property:unchecked"
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-rsa-md4"
+    categories:
+      - "permissive"
+      - "property:advertising-clause"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-secret-labs-2011"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://scancode-licensedb.aboutcode.org/service-comp-arch.html
+  - id: "LicenseRef-scancode-service-comp-arch"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://github.com/nexB/scancode-toolkit/blob/ded56e9120f5fdfb9a1a0309130bb4305a66aacb/src/licensedcode/data/licenses/snprintf.LICENSE
+  - id: "LicenseRef-scancode-snprintf"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-srgb"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-ssleay-windows"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:advertising-clause"
+
+  - id: "LicenseRef-scancode-sun-bsd-extra"
+    categories:
+      - "free-restricted"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-sun-ejb-spec-3.0"
+    categories:
+      - "proprietary-free"
+      - "property:patent-clause"
+
+  - id: "LicenseRef-scancode-sun-jsr-spec-04-2006"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-sun-prop-non-commercial"
+    categories:
+      - "proprietary-free"
+      - "property:non-commercial"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-sun-sdk-spec-1.1"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-sunpro"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-taligent-jdk"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-tex-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-tim-janik-2003"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-ubuntu-font-1.0"
+    categories:
+      - "free-restricted"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-unicode"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-unicode-mappings"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-unknown"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "LicenseRef-scancode-unknown-license-reference"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "LicenseRef-scancode-unknown-spdx"
+    categories:
+      - "unstated"
+
+  - id: "LicenseRef-scancode-unlimited-link-exception-lgpl"
+    categories:
+      - "copyleft-LGPL"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-scancode-us-govt-public-domain"
+    categories:
+      - "public-domain"
+
+  - id: "LicenseRef-scancode-w3c-docs-19990405"
+    categories:
+      - "property:unchecked"
+      - "free-restricted"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-w3c-docs-20021231"
+    categories:
+      - "free-restricted"
+      - "property:include-in-notice-file"
+
+  # https://www.w3.org/copyright/test-suite-license-2008/
+  - id: "LicenseRef-scancode-w3c-test-suite"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-warranty-disclaimer"
+    categories:
+      - "irrelevant"
+
+  - id: "LicenseRef-scancode-ws-addressing-spec"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-ws-policy-specification"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-ws-trust-specification"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-x11-hanson"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-x11-lucent"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-x11-opengroup"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-x11-stanford"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-scancode-zipeg"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-sflow-license"
+    categories:
+      - "proprietary-free"
+
+  - id: "LicenseRef-st-mcd-2.0"
+    categories:
+      - "free-restricted"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-stmicroelectronics-linux-firmware"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-synopsys-attribution"
+    categories:
+      - "free-restricted"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-tested-software"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-tso-license"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "LicenseRef-u-boot-exception-2.0"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  - id: "LicenseRef-ubuntu-font-1.0"
+    categories:
+      - "free-restricted"
+      - "property:include-in-notice-file"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "LicenseRef-verbatim-distribution-license"
+    categories:
+      - "property:include-in-notice-file"
+      - "permissive"
+
+  - id: "LicenseRef-verbatim-no-modifications"
+    categories:
+      - "proprietary-free"
+
+  - id: "Linux-OpenIB"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "Linux-syscall-note"
+    categories:
+      - "property:AutoConf-or-other-exception"
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/MIT.html
+  - id: "MIT"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/MIT-0.html
+  - id: "MIT-0"
+    categories:
+      - "permissive"
+
+  # https://spdx.org/licenses/MIT-CMU.html
+  - id: "MIT-CMU"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "MIT-CMU-style"
+    categories:
+      - "permissive"
+
+  # https://spdx.org/licenses/MIT-feh.html
+  - id: "MIT-feh"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "MIT-old-style-no-adv"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/MIT-open-group.html
+  - id: "MIT-open-group"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "MIT-possibility"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "MIT-style"
+    categories:
+      - "permissive"
+
+  - id: "MPL"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  # https://spdx.org/licenses/MPL-1.0.html
+  - id: "MPL-1.0"
+    categories:
+      - "copyleft-file-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/MPL-1.1.html
+  - id: "MPL-1.1"
+    categories:
+      - "copyleft-file-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  # https://spdx.org/licenses/MPL-2.0.html
+  - id: "MPL-2.0"
+    categories:
+      - "copyleft-file-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  - id: "MPL-2.0-no-copyleft-exception"
+    categories:
+      - "copyleft-file-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  # https://scancode-licensedb.aboutcode.org/ms-lpl.html
+  - id: "MS-LPL"
+    categories:
+      - "free-restricted"
+      - "property:include-in-notice-file"
+      - "property:patent-clause"
+      - "property:unchecked"
+
+  # https://spdx.org/licenses/MS-PL.html
+  - id: "MS-PL"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:patent-clause"
+
+  # https://spdx.org/licenses/MS-RL.html
+  - id: "MS-RL"
+    categories:
+      - "copyleft-file-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  # https://spdx.org/licenses/MTLL.html
+  - id: "MTLL"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "Microsoft"
+    categories:
+      - "proprietary-free"
+
+  - id: "Microsoft-possibility"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "Minpack"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "Motorola"
+    categories:
+      - "commercial"
+
+  - id: "NCSA"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "NIST-PD"
+    categories:
+      - "public-domain"
+
+  - id: "NOSL"
+    categories:
+      - "copyleft-file-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  - id: "NOT-public-domain"
+    categories:
+      - "irrelevant"
+
+  # https://spdx.org/licenses/NPL-1.1.html
+  - id: "NPL-1.1"
+    categories:
+      - "copyleft-file-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:patent-clause"
+
+  - id: "NRL"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:advertising-clause"
+
+  # https://spdx.org/licenses/NTP.html
+  - id: "NTP"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "NTP-0"
+    categories:
+      - "permissive"
+
+  - id: "NetCDF"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "NewBSD"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "Non-commercial"
+    categories:
+      - "property:unchecked"
+      - "property:non-commercial"
+
+  - id: "Non-profit"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "Not-Free"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "Not-for-sale"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "NotreDame-style"
+    categories:
+      - "permissive"
+
+  - id: "Noweb"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+
+  - id: "Nvidia-EULA-b"
+    categories:
+      - "commercial"
+
+  # https://spdx.org/licenses/ODC-By-1.0.html
+  - id: "ODC-By-1.0"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/ODbL-1.0.html
+  - id: "ODbL-1.0"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/OFL-1.0.html
+  - id: "OFL-1.0"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/OFL-1.1.html
+  - id: "OFL-1.1"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/OFL-1.1-no-RFN.html
+  - id: "OFL-1.1-no-RFN"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "OGC-1.0"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "OGL-UK-3.0"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "OLDAP"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/OLDAP-2.0.1.html
+  - id: "OLDAP-2.0.1"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/OLDAP-2.8.html
+  - id: "OLDAP-2.8"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "OSF-style"
+    categories:
+      - "property:unclear-scanner-finding"
 
   # https://spdx.org/licenses/OSL-2.1.html
   - id: "OSL-2.1"
@@ -4492,33 +4016,351 @@ categorizations:
       - "property:distribute-source-code"
       - "property:patent-clause"
 
-  # https://spdx.org/licenses/LGPL-2.0-or-later.html
-  # https://spdx.org/licenses/OCaml-LGPL-linking-exception.html
-  - id: "LGPL-2.0-or-later WITH OCaml-LGPL-linking-exception"
+  # https://spdx.org/licenses/OpenSSL.html
+  - id: "OpenSSL"
     categories:
-      - "copyleft-LGPL"
+      - "permissive"
+      - "property:advertising-clause"
       - "property:include-in-notice-file"
-      - "property:distribute-source-code"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "OpenSSL-exception"
+    categories:
       - "property:AutoConf-or-other-exception"
 
-  # https://spdx.org/licenses/BSD-3-Clause-Modification.html
-  - id: "BSD-3-Clause-Modification"
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "PCRE"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:unchecked"
+
+  - id: "PSF-2.0"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "Patent-ref"
+    categories:
+      - "irrelevant"
+
+  - id: "Perl-possibility"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "Permissive-no-warranty"
+    categories:
+      - "permissive"
+
+  - id: "Plexus"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "PostgreSQL"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "Public-domain"
+    categories:
+      - "public-domain"
+
+  - id: "Public-domain-ref "
+    categories:
+      - "public-domain"
+
+  - id: "Public-domainC"
+    categories:
+      - "public-domain"
+
+  - id: "Python"
+    categories:
+      - "property:include-in-notice-file"
+      - "permissive"
+
+  # https://spdx.org/licenses/Python-2.0.html
+  - id: "Python-2.0"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://www.python.org/download/releases/2.0.1/license/
+  - id: "Python-2.0.1"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
       - "property:mark-modifications"
 
-  - id: "LicenseRef-scancode-freebsd-boot"
+  # https://www.python.org/download/releases/2.1.1/license/
+  - id: "Python-2.1.1"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
 
-  - id: "LicenseRef-scancode-nilsson-historical"
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "Python-2.2"
+    categories:
+      - "property:include-in-notice-file"
+      - "permissive"
+
+  - id: "Qhull"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
 
-  - id: "LicenseRef-scancode-bsd-no-disclaimer-unmodified"
+  - id: "RHeCos-1.1"
+    categories:
+      - "copyleft-file-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:unchecked"
+
+  - id: "RSA-Cryptoki"
+    categories:
+      - "permissive"
+      - "property:advertising-clause"
+      - "property:include-in-notice-file"
+
+  - id: "RSA-MD"
+    categories:
+      - "property:advertising-clause"
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "RSA-possibility"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "Rdisc"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "RedHat"
+    categories:
+      - "commercial"
+
+  # https://spdx.org/licenses/Ruby.html
+  - id: "Ruby"
+    categories:
+      - "copyleft-file-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/SAX-PD.html
+  - id: "SAX-PD"
+    categories:
+      - "public-domain"
+
+  - id: "SISSL"
+    categories:
+      - "proprietary-free"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  # https://spdx.org/licenses/SMLNJ.html
+  - id: "SMLNJ"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "SSH-OpenSSH"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "SSH-short"
+    categories:
+      - "permissive"
+
+  # http://publib.boulder.ibm.com/tividd/td/TWS/SC32-1267-00/en_US/HTML/eqqm1mst68.htm
+  - id: "SSLeay"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:advertising-clause"
+
+  - id: "Same-license-as"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "Saxpath"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "See-URL"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "See-doc.OTHER"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "See-file"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "See-file.COPYING"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "See-file.LICENSE"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "See-file.README"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  # https://spdx.org/licenses/Spencer-86.html
+  - id: "Spencer-86"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/Spencer-94.html
+  - id: "Spencer-94"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "Sun-RPC"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "Sun-possibility"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "SunPro"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "TCL"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "TCP-wrappers"
+    categories:
+      - "property:include-in-notice-file"
+      - "permissive"
+
+  - id: "TMate"
+    categories:
+      - "property:unchecked"
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+
+  - id: "TeX-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  - id: "U-Mich-style"
+    categories:
+      - "permissive"
+
+  - id: "U-Michigan"
+    categories:
+      - "permissive"
+
+  - id: "USC"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "UnclassifiedLicense"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "Unicode"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/Unicode-DFS-2015.html
+  - id: "Unicode-DFS-2015"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/Unicode-DFS-2016.html
+  - id: "Unicode-DFS-2016"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "Unicode-TOU"
+    categories:
+      - "proprietary-free"
+
+  - id: "Universal-FOSS-exception-1.0"
+    categories:
+      - "property:AutoConf-or-other-exception"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/Unlicense.html
+  - id: "Unlicense"
+    categories:
+      - "public-domain"
+
+  - id: "Vim"
+    categories:
+      - "copyleft-module-level"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/W3C.html
+  - id: "W3C"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "W3C-19980720"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/W3C-20150513.html
+  - id: "W3C-20150513"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "W3C-IP"
+    categories:
+      - "property:unclear-scanner-finding"
+
+  - id: "W3C-possibility"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/W3C.html
+  - id: "W3C-style"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/WTFPL.html
+  - id: "WTFPL"
+    categories:
+      - "public-domain"
+
+  # https://scancode-licensedb.aboutcode.org/wordnet.html
+  - id: "WordNet-3.0"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/X11.html
+  - id: "X11"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
@@ -4529,56 +4371,213 @@ categorizations:
       - "permissive"
       - "property:include-in-notice-file"
 
-  - id: "LicenseRef-scancode-ssleay-windows"
+  - id: "X11-possibility"
+    categories:
+      - "permissive"
+
+  - id: "X11-style"
+    categories:
+      - "permissive"
+
+  - id: "XFree86"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "Xerox"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/YPL-1.0.html
+  - id: "YPL-1.0"
+    categories:
+      - "copyleft-file-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+
+  - id: "ZPL"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "ZPL-2.1"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/Zed.html
+  - id: "Zed"
+    categories:
+      - "free-restricted"
+
+  - id: "Zend-2.0"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
       - "property:advertising-clause"
 
-  - id: "LicenseRef-scancode-fsf-notice"
-    categories:
-      - "permissive"
-
-  - id: "LicenseRef-scancode-bsd-unchanged"
+  # https://spdx.org/licenses/Zlib.html
+  - id: "Zlib"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
 
-  - id: "LicenseRef-scancode-robert-hubley"
+  - id: "Zlib-possibility"
     categories:
-      - "irrelevant"
+      - "permissive"
 
-  # https://spdx.org/licenses/GFDL-1.2.html
-  - id: "GFDL-1.2-only"
+  # https://spdx.org/licenses/Zlib.html
+  - id: "Zlib-style"
     categories:
-      - "copyleft-module-level"
+      - "permissive"
       - "property:include-in-notice-file"
+
+  - id: "blessing"
+    categories:
+      - "public-domain"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "bzip2"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/bzip2-1.0.5.html
+  - id: "bzip2-1.0.5"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://spdx.org/licenses/bzip2-1.0.5.html
+  - id: "bzip2-1.0.6"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  # https://raw.githubusercontent.com/copyleft-next/copyleft-next/master/Releases/copyleft-next-0.3.1
+  - id: "copyleft-next-0.3.1"
+    categories:
+      - "copyleft-strong"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
       - "property:unchecked"
 
-  - id: "LicenseRef-scancode-mit-veillard-variant"
+  # https://spdx.org/licenses/curl.html
+  - id: "curl"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
 
-  # https://spdx.org/licenses/SMLNJ.html
-  - id: "SMLNJ"
+  - id: "eCos-2.0"
+    categories:
+      - "copyleft-file-level"
+      - "property:include-in-notice-file"
+      - "property:distribute-source-code"
+      - "property:unchecked"
+
+  - id: "eCos-exception-2.0"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  # https://scancode-licensedb.aboutcode.org/fsf-unlimited-no-warranty.html
+  - id: "fsf-unlimited-no-warranty"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
 
-  - id: "LicenseRef-scancode-bsd-unmodified"
+  - id: "gary-s-brown"
+    categories:
+      - "permissive"
+
+  # https://spdx.org/licenses/Autoconf-exception-3.0.html
+  - id: "gnu-javamail-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/libselinux-1.0.html
+  - id: "libselinux-1.0"
+    categories:
+      - "public-domain"
+
+  - id: "linking-exception"
+    categories:
+      - "property:unchecked"
+      - "property:AutoConf-or-other-exception"
+
+  - id: "mif-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  # https://spdx.org/licenses/mplus.html
+  - id: "mplus"
+    categories:
+      - "permissive"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "naist-2003"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
 
-  - id: "LicenseRef-scancode-carnegie-mellon"
+  - id: "openvpn-openssl-exception"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  - id: "redistribution-only-license"
+    categories:
+      - "proprietary-free"
+
+  - id: "scancode-mit-old-style"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
 
-  # https://www.eclipse.org/legal/tck.php
-  - id: "LicenseRef-EFTCK-1.0"
+  # https://spdx.org/licenses/snprintf.html
+  - id: "snprintf"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "st-mcd-2.0"
     categories:
       - "free-restricted"
       - "property:include-in-notice-file"
-      - "property:no-modifications"
+
+  # Duplicate of the previous classification due to tooling requirements.
+  - id: "synopsys-attribution"
+    categories:
+      - "free-restricted"
+      - "property:include-in-notice-file"
+
+  - id: "tso-license"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+
+  - id: "u-boot-exception-2.0"
+    categories:
+      - "property:AutoConf-or-other-exception"
+
+  - id: "ubuntu-font-1.0"
+    categories:
+      - "property:include-in-notice-file"
+      - "free-restricted"
+
+  - id: "verbatim-distribution-license"
+    categories:
+      - "property:include-in-notice-file"
+      - "permissive"
+
+  # https://spdx.org/licenses/xpp.html
+  - id: "xpp"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"
+      - "property:advertising-clause"
+
+  # https://spdx.org/licenses/zlib-acknowledgement.html
+  - id: "zlib-acknowledgement"
+    categories:
+      - "permissive"
+      - "property:include-in-notice-file"

--- a/sort-licenses.py
+++ b/sort-licenses.py
@@ -1,0 +1,64 @@
+import re
+import argparse
+
+def sort_yaml_blocks(input_file, output_file):
+    with open(input_file, 'r') as f:
+        lines = f.readlines()
+
+    prefix = []
+    blocks = []
+    block = []
+    comments = []
+    in_categorizations = False
+
+    for line in lines:
+        if "categorizations:" in line:
+            in_categorizations = True
+            prefix.append(line)
+            continue
+
+        if not in_categorizations:
+            prefix.append(line)
+            continue
+
+        if re.match(r"\s*#", line):
+            comments.append(line)
+        elif re.match(r"\s*- id:", line):
+            if block:  # Add non-empty block to blocks
+                blocks.append("".join(block))
+            block = comments + [line]
+            comments = []
+        else:
+            block.append(line)
+
+    # Add the last block if it's non-empty
+    if block:
+        blocks.append("".join(block))
+
+    def sorting_key(x):
+        match = re.search(r'- id: "(.*)"', x)
+        if match:
+            return match.group(1)
+        else:
+            raise ValueError(f"Sorting key not found in block:\n{x}")
+
+    try:
+        blocks.sort(key=sorting_key)
+    except ValueError as e:
+        print(f"Exception while sorting: {e}")
+
+    with open(output_file, 'w') as f:
+        f.writelines(prefix)
+        f.writelines(blocks)
+
+def main():
+    parser = argparse.ArgumentParser(description="Sort licenses based on 'id' field within 'categorizations'.")
+    parser.add_argument('input_file', type=str, help='Input YAML file, usually license-classifications.yml')
+    parser.add_argument('output_file', type=str, help='Output YAML file after sorting. Once verified, you can replace the current license-classifications.yml with this file.')
+
+    args = parser.parse_args()
+
+    sort_yaml_blocks(args.input_file, args.output_file)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduces a sorting script sort_licenses.py for the license-classifications.yml.  Moreover, it has been used to sort the licenses in the latter, for better readability and maintainability.

The sorted license classifications file has been tested by running ORT Evaluate for X-Road project and verifying that the results are the same as before sorting, everything else in ORT environment being kept static.