### PR TITLE
Introduce a stand-alone Kotlin script to check license classifications

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,9 +12,6 @@ on:
     branches:
       - "main"
 
-env:
-  ORT_VERSION: 9.0.0
-
 jobs:
   Check:
     runs-on: ubuntu-latest
@@ -27,12 +24,8 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-      - name: Setup ORT helper-cli
-        run: |
-          wget https://github.com/oss-review-toolkit/ort/releases/download/$ORT_VERSION/orth-$ORT_VERSION.zip
-          unzip orth-$ORT_VERSION.zip -d /opt
-      - name: Check license-classifications.yml
-        run: /opt/orth-$ORT_VERSION/bin/orth list-license-categories -i license-classifications.yml
+      - name: Check license classifications
+        run: ./scripts/check-license-classifications.main.kts
 
   Lint:
     runs-on: ubuntu-latest

--- a/scripts/check-license-classifications.main.kts
+++ b/scripts/check-license-classifications.main.kts
@@ -1,0 +1,27 @@
+#!/usr/bin/env kotlin
+
+// SPDX-FileCopyrightText: 2023 Double Open Oy <support@doubleopen.org>
+// SPDX-License-Identifier: CC0-1.0
+
+@file:CompilerOptions("-jvm-target", "17")
+@file:DependsOn("org.ossreviewtoolkit:model:10.0.0")
+
+import java.io.File
+
+import kotlin.system.exitProcess
+
+import org.ossreviewtoolkit.model.licenses.LicenseClassifications
+import org.ossreviewtoolkit.model.readValue
+
+val scriptsDir = __FILE__.parentFile
+val licenseClassificationsFile = scriptsDir.resolve("../license-classifications.yml").canonicalFile
+
+val licenseClassifications = runCatching {
+    licenseClassificationsFile.readValue<LicenseClassifications>()
+}.onFailure {
+    println("Unable to read '$licenseClassificationsFile': ${it.message}")
+}.getOrElse {
+    exitProcess(1)
+}
+
+println("Check passed for '$licenseClassificationsFile'.")


### PR DESCRIPTION
This offers more flexibility going forward, like checking that all classified licenses are valid SPDX IDs.