### PR TITLE
Implement basic checks on classified licenses

### DIFF
--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2024 Double Open Oy <support@doubleopen.org>
+# SPDX-License-Identifier: CC0-1.0
+
+/.gradle/
+/gradle/
+gradlew
+gradlew.bat

--- a/scripts/build.gradle.kts
+++ b/scripts/build.gradle.kts
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2024 Double Open Oy <support@doubleopen.org>
+// SPDX-License-Identifier: CC0-1.0
+
+// This is a dummy file to make Fleet recognize `.main.kts` scripts in this folder, see
+// https://youtrack.jetbrains.com/issue/FL-22261.

--- a/scripts/check-license-classifications.main.kts
+++ b/scripts/check-license-classifications.main.kts
@@ -6,8 +6,6 @@
 @file:CompilerOptions("-jvm-target", "11")
 @file:DependsOn("org.ossreviewtoolkit:model:18.0.0")
 
-import java.io.File
-
 import kotlin.system.exitProcess
 
 import org.ossreviewtoolkit.model.licenses.LicenseClassifications

--- a/scripts/check-license-classifications.main.kts
+++ b/scripts/check-license-classifications.main.kts
@@ -10,6 +10,7 @@ import kotlin.system.exitProcess
 
 import org.ossreviewtoolkit.model.licenses.LicenseClassifications
 import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.utils.spdx.SpdxExpression.Strictness
 
 val scriptsDir = __FILE__.parentFile
 val licenseClassificationsFile = scriptsDir.resolve("../license-classifications.yml").canonicalFile
@@ -19,6 +20,16 @@ val licenseClassifications = runCatching {
 }.onFailure {
     println("Unable to read '$licenseClassificationsFile': ${it.message}")
 }.getOrElse {
+    exitProcess(1)
+}
+
+val (validLicenses, invalidLicenses) = licenseClassifications.categoriesByLicense.keys.partition {
+    it.isValid(Strictness.ALLOW_ANY)
+}
+
+if (invalidLicenses.isNotEmpty()) {
+    println("The following licenses cannot be parsed as SPDX license expressions:")
+    println(invalidLicenses.joinToString("\n"))
     exitProcess(1)
 }
 

--- a/scripts/check-license-classifications.main.kts
+++ b/scripts/check-license-classifications.main.kts
@@ -3,8 +3,8 @@
 // SPDX-FileCopyrightText: 2023 Double Open Oy <support@doubleopen.org>
 // SPDX-License-Identifier: CC0-1.0
 
-@file:CompilerOptions("-jvm-target", "17")
-@file:DependsOn("org.ossreviewtoolkit:model:10.0.0")
+@file:CompilerOptions("-jvm-target", "11")
+@file:DependsOn("org.ossreviewtoolkit:model:18.0.0")
 
 import java.io.File
 


### PR DESCRIPTION
Please have a look at the individual commit messages for the details. 

*Edit:* See [here](https://github.com/doubleopen-project/policy-configuration/actions/runs/7220929411/job/19674823090?pr=64#step:4:8) for the list of licenses that'd need to be fixed according to this new check.