### PR TITLE
chore: Turn URL comments into properties

### DIFF
--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -205,12 +205,12 @@ categorizations:
     categories:
       - "property:AutoConf-or-other-exception"
 
-  # https://spdx.org/licenses/AFL-1.1.html
   - id: "AFL-1.1"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
       - "property:patent-clause"
+      - "url:https://spdx.org/licenses/AFL-1.1.html"
 
   # https://spdx.org/licenses/AFL-1.2.html
   - id: "AFL-1.2"


### PR DESCRIPTION
This is just an idea that I only implemented at a single example to clarify: How do @doubleopen-project/team think about turning URL comments into properties, so they become machine readable / actionable in rules?