### PR TITLE
Turn on workflow-dispatch for the Github workflow "Check"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     branches:
       - "main"
+  workflow_dispatch:
 
 jobs:
   Check:


### PR DESCRIPTION
To be able to run the check.yml workflow manually on Github - for example when modifications to license-classifications.yml are made - the workflow-dispatch event is added to the check.yml workflow.

With this addition, anyone who creates a new branch to modify the license-classifications.yml and pushes changes to the branch, can go to Github, select Actions, select the check.yml workflow and run the workflow manually for the corresponding branch, to check that the workflow passes.

These manual check runs can thus be triggered even before a PR is created.