### PR TITLE
License cleanup

### DIFF
--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -206,10 +206,6 @@ categorizations:
     categories:
       - "permissive"
 
-  - id: "389-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
   # https://spdx.org/licenses/AFL-1.1.html
   - id: "AFL-1.1"
     categories:
@@ -478,20 +474,6 @@ categorizations:
       - "property:distribute-source-code"
       - "property:patent-clause"
 
-  - id: "Autoconf-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/Autoconf-exception-2.0.html
-  - id: "Autoconf-exception-2.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/Autoconf-exception-3.0.html
-  - id: "Autoconf-exception-3.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
   # https://spdx.org/licenses/BlueOak-1.0.0.html
   - id: "BlueOak-1.0.0"
     categories:
@@ -687,11 +669,6 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  # https://spdx.org/licenses/Bison-exception-2.2.html
-  - id: "Bison-exception-2.2"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
   # https://spdx.org/licenses/BitTorrent-1.0.html
   - id: "BitTorrent-1.0"
     categories:
@@ -715,11 +692,6 @@ categorizations:
       - "free-restricted"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
-
-  # https://spdx.org/licenses/Bootloader-exception.html
-  - id: "Bootloader-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
 
   # https://spdx.org/licenses/Borceux.html
   - id: "Borceux"
@@ -1054,13 +1026,6 @@ categorizations:
       - "property:distribute-source-code"
       - "property:patent-clause"
 
-  # https://spdx.org/licenses/Classpath-exception-2.0.html
-  - id: "Classpath-exception-2.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
   - id: "Cryptogams"
     categories:
       - "permissive"
@@ -1175,11 +1140,6 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  # https://spdx.org/licenses/Font-exception-2.0.html
-  - id: "Font-exception-2.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
   - id: "Free-SW"
     categories:
       - "permissive"
@@ -1195,16 +1155,6 @@ categorizations:
   - id: "Freeware"
     categories:
       - "proprietary-free"
-
-  # https://spdx.org/licenses/GCC-exception-2.0.html
-  - id: "GCC-exception-2.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GCC-exception-3.1.html
-  - id: "GCC-exception-3.1"
-    categories:
-      - "property:AutoConf-or-other-exception"
 
   # https://spdx.org/licenses/GFDL-1.3.html
   - id: "GFDL"
@@ -1569,10 +1519,6 @@ categorizations:
       - "property:distribute-source-code"
       - "property:patent-clause"
 
-  - id: "GPL-3.0-linking-source-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
   # https://spdx.org/licenses/GPL-3.0-only.html
   - id: "GPL-3.0-only"
     categories:
@@ -1748,10 +1694,6 @@ categorizations:
       - "property:distribute-source-code"
       - "property:patent-clause"
       - "property:AutoConf-or-other-exception"
-
-  - id: "GPL-exception"
-    categories:
-      - "irrelevant"
 
   - id: "GPL-possibility"
     categories:
@@ -2110,11 +2052,6 @@ categorizations:
     categories:
       - "property:unclear-scanner-finding"
 
-  # https://spdx.org/licenses/LLVM-exception.html
-  - id: "LLVM-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
   # https://spdx.org/licenses/LPL-1.02.html
   - id: "LPL-1.02"
     categories:
@@ -2194,11 +2131,6 @@ categorizations:
       - "permissive"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
-
-  # https://spdx.org/licenses/Libtool-exception.html
-  - id: "Libtool-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
 
   - id: "LicenseRef-389-exception"
     categories:
@@ -4411,11 +4343,6 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "OpenSSL-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
   - id: "PSF-2.0"
     categories:
       - "permissive"
@@ -4657,10 +4584,6 @@ categorizations:
       - "include-in-notice-file"
       - "property:distribute-source-code"
 
-  - id: "TeX-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
   - id: "U-Mich-style"
     categories:
       - "permissive"
@@ -4703,12 +4626,6 @@ categorizations:
   - id: "Unicode-TOU"
     categories:
       - "proprietary-free"
-
-  - id: "Universal-FOSS-exception-1.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
 
   # https://spdx.org/licenses/Unlicense.html
   - id: "Unlicense"
@@ -4914,10 +4831,6 @@ categorizations:
       - "property:distribute-source-code"
       - "property:unchecked"
 
-  - id: "eCos-exception-2.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
   # https://scancode-licensedb.aboutcode.org/fsf-unlimited-no-warranty.html
   - id: "fsf-unlimited-no-warranty"
     categories:
@@ -4929,24 +4842,10 @@ categorizations:
     categories:
       - "permissive"
 
-  # https://spdx.org/licenses/Autoconf-exception-3.0.html
-  - id: "gnu-javamail-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
-
   # https://spdx.org/licenses/libselinux-1.0.html
   - id: "libselinux-1.0"
     categories:
       - "public-domain"
-
-  - id: "linking-exception"
-    categories:
-      - "property:unchecked"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "mif-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
 
   # https://spdx.org/licenses/mplus.html
   - id: "mplus"
@@ -4959,10 +4858,6 @@ categorizations:
       - "permissive"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
-
-  - id: "openvpn-openssl-exception"
-    categories:
-      - "property:AutoConf-or-other-exception"
 
   - id: "redistribution-only-license"
     categories:
@@ -4992,10 +4887,6 @@ categorizations:
       - "permissive"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
-
-  - id: "u-boot-exception-2.0"
-    categories:
-      - "property:AutoConf-or-other-exception"
 
   - id: "ubuntu-font-1.0"
     categories:

--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -248,15 +248,6 @@ categorizations:
       - "property:network-clause"
 
   # https://spdx.org/licenses/AGPL-1.0-only.html
-  - id: "AGPL-1.0"
-    categories:
-      - "copyleft-strong"
-      - "property:network-clause"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/AGPL-1.0-only.html
   - id: "AGPL-1.0-only"
     categories:
       - "copyleft-strong"
@@ -273,17 +264,6 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
       - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/AGPL-3.0-only.html
-  - id: "AGPL-3.0"
-    categories:
-      - "copyleft-strong"
-      - "property:network-clause"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
 
   # https://spdx.org/licenses/AGPL-3.0-only.html
   - id: "AGPL-3.0-only"
@@ -306,12 +286,6 @@ categorizations:
       - "property:antitivo-clause"
       - "property:distribute-source-code"
       - "property:patent-clause"
-
-  - id: "AMD"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
 
   # https://spdx.org/licenses/AMDPLPA.html
   - id: "AMDPLPA"
@@ -377,12 +351,6 @@ categorizations:
       - "property:patent-clause"
       - "property:distribute-source-code"
 
-  - id: "ATT"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
   # https://spdx.org/licenses/Adobe-2006.html
   - id: "Adobe-2006"
     categories:
@@ -393,10 +361,6 @@ categorizations:
       - "permissive"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
-
-  - id: "Apache"
-    categories:
-      - "property:unclear-scanner-finding"
 
   # https://spdx.org/licenses/Apache-1.0.html
   - id: "Apache-1.0"
@@ -430,14 +394,6 @@ categorizations:
       - "include-in-notice-file"
       - "property:patent-clause"
       - "property:AutoConf-or-other-exception"
-
-  - id: "Apache-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "Apple.Sample"
-    categories:
-      - "permissive"
 
   # https://spdx.org/licenses/Artistic-1.0.html
   - id: "Artistic-1.0"
@@ -481,10 +437,6 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  - id: "BSD"
-    categories:
-      - "permissive"
-
   # https://spdx.org/licenses/BSD-1-Clause.html
   - id: "BSD-1-Clause"
     categories:
@@ -492,28 +444,8 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  - id: "BSD-2"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
   # https://spdx.org/licenses/BSD-2-Clause.html
   - id: "BSD-2-Clause"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
-  # https://github.com/nexB/scancode-licensedb/blob/main/docs/bsd-2-clause-freebsd.yml
-  - id: "BSD-2-Clause-FreeBSD"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
-  # https://github.com/nexB/scancode-licensedb/blob/main/docs/bsd-2-clause-netbsd.yml
-  - id: "BSD-2-Clause-NetBSD"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
@@ -588,12 +520,6 @@ categorizations:
       - "include-in-notice-file"
       - "property:advertising-clause"
 
-  - id: "BSD-4-Clause-NetBSD"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
   - id: "BSD-4-Clause-Shortened"
     categories:
       - "permissive"
@@ -637,25 +563,12 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  - id: "BSD-possibility"
-    categories:
-      - "permissive"
-
-  # Inaccurate but permissive license hits.
-  - id: "BSD-style"
-    categories:
-      - "permissive"
-
   # https://spdx.org/licenses/BSL-1.0.html
   - id: "BSL-1.0"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
-
-  - id: "BSL-style"
-    categories:
-      - "permissive"
 
   - id: "BUSL-1.1"
     categories:
@@ -968,10 +881,6 @@ categorizations:
       - "public-domain"
       - "property:creativecommons"
 
-  - id: "CCPL"
-    categories:
-      - "property:unclear-scanner-finding"
-
   # https://spdx.org/licenses/CDDL-1.0.html
   - id: "CDDL-1.0"
     categories:
@@ -1004,10 +913,6 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  - id: "COMMERCIAL"
-    categories:
-      - "commercial"
-
   # https://spdx.org/licenses/CPL-1.0.html
   - id: "CPL-1.0"
     categories:
@@ -1026,27 +931,11 @@ categorizations:
       - "property:distribute-source-code"
       - "property:patent-clause"
 
-  - id: "Cryptogams"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
-  - id: "DEC-Unknown-License"
-    categories:
-      - "commercial"
-
   - id: "DOC"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
-
-  - id: "Debian-SPI-style"
-    categories:
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "permissive"
 
   # https://spdx.org/licenses/ECL-2.0.html
   - id: "ECL-2.0"
@@ -1055,12 +944,6 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
       - "property:patent-clause"
-
-  - id: "EDL-1.0"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
 
   # https://spdx.org/licenses/EPL-1.0.html
   - id: "EPL-1.0"
@@ -1104,10 +987,6 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  - id: "FSF"
-    categories:
-      - "permissive"
-
   # https://spdx.org/licenses/FSFAP.html
   - id: "FSFAP"
     categories:
@@ -1140,37 +1019,11 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  - id: "Free-SW"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
   - id: "FreeImage"
     categories:
       - "copyleft-module-level"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
-
-  - id: "Freeware"
-    categories:
-      - "proprietary-free"
-
-  # https://spdx.org/licenses/GFDL-1.3.html
-  - id: "GFDL"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:unchecked"
-
-  # https://spdx.org/licenses/GFDL-1.1.html
-  - id: "GFDL-1.1"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:unchecked"
 
   # https://spdx.org/licenses/GFDL-1.1.html
   - id: "GFDL-1.1-only"
@@ -1182,14 +1035,6 @@ categorizations:
 
   # https://spdx.org/licenses/GFDL-1.1.html
   - id: "GFDL-1.1-or-later"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:unchecked"
-
-  # https://spdx.org/licenses/GFDL-1.2.html
-  - id: "GFDL-1.2"
     categories:
       - "copyleft-module-level"
       - "property:include-in-notice-file"
@@ -1213,14 +1058,6 @@ categorizations:
       - "property:unchecked"
 
   # https://spdx.org/licenses/GFDL-1.3.html
-  - id: "GFDL-1.3"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:unchecked"
-
-  # https://spdx.org/licenses/GFDL-1.3.html
   - id: "GFDL-1.3-only"
     categories:
       - "copyleft-module-level"
@@ -1235,22 +1072,6 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
       - "property:unchecked"
-
-  - id: "GNU-Manpages"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "GPL"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  # https://spdx.org/licenses/GPL-1.0-only.html
-  - id: "GPL-1.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:distribute-source-code"
 
   # https://spdx.org/licenses/GPL-1.0-only.html
   - id: "GPL-1.0-only"
@@ -1281,34 +1102,6 @@ categorizations:
   # https://spdx.org/licenses/GPL-1.0-or-later.html
   # https://spdx.org/licenses/Linux-syscall-note.html
   - id: "GPL-1.0-or-later WITH Linux-syscall-note"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-only.html
-  - id: "GPL-2.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/GPL-2.0-only.html
-  # https://spdx.org/licenses/Classpath-exception-2.0.html
-  - id: "GPL-2.0 WITH Classpath-exception-2.0"
-    categories:
-      - "copyleft-module-level"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-only.html
-  # https://spdx.org/licenses/OpenJDK-assembly-exception-1.0.html
-  - id: "GPL-2.0 WITH OpenJDK-assembly-exception-1.0"
     categories:
       - "copyleft-strong"
       - "property:include-in-notice-file"
@@ -1468,57 +1261,6 @@ categorizations:
       - "property:distribute-source-code"
       - "property:AutoConf-or-other-exception"
 
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "GPL-2.0-or-later-WITH-Autoconf-exception-2.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "GPL-2.0-or-later-with-autoconf-macro-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-or-later.html
-  # https://spdx.org/licenses/Bison-exception-2.2.html
-  - id: "GPL-2.0-or-later-with-bison-exception-2.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-2.0-only.html
-  # https://spdx.org/licenses/GCC-exception-2.0.html
-  - id: "GPL-2.0-with-GCC-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "GPL-2.1sic"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  # https://spdx.org/licenses/GPL-3.0-only.html
-  - id: "GPL-3.0"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
   # https://spdx.org/licenses/GPL-3.0-only.html
   - id: "GPL-3.0-only"
     categories:
@@ -1671,46 +1413,6 @@ categorizations:
       - "property:patent-clause"
       - "property:AutoConf-or-other-exception"
 
-  # https://spdx.org/licenses/GPL-3.0-or-later.html
-  # https://spdx.org/licenses/Bison-exception-2.2.html
-  - id: "GPL-3.0-or-later-WITH-Bison-exception-2.2"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/GPL-3.0-or-later.html
-  # http://git.openembedded.org/openembedded-core/tree/meta/files/common-licenses/GPL-2.0-with-autoconf-exception
-  - id: "GPL-3.0-or-later-with-Autoconf-macro-exception"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-      - "property:AutoConf-or-other-exception"
-
-  - id: "GPL-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "HP-Compaq"
-    categories:
-      - "irrelevant"
-
-  - id: "HP-DEC"
-    categories:
-      - "commercial"
-
-  - id: "HP-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
-
   # https://spdx.org/licenses/HPND.html
   - id: "HPND"
     categories:
@@ -1725,12 +1427,6 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  - id: "IBM-dhcp"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
   # https://spdx.org/licenses/IBM-pibs.html
   - id: "IBM-pibs"
     categories:
@@ -1738,26 +1434,8 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  - id: "IBM-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
-
   # https://spdx.org/licenses/ICU.html
   - id: "ICU"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "IETF"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
-  # https://scancode-licensedb.aboutcode.org/ietf.html
-  - id: "IETF-style"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
@@ -1767,16 +1445,6 @@ categorizations:
   - id: "IJG"
     categories:
       - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
-  - id: "IJG-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "IOS"
-    categories:
-      - "proprietary-free"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
@@ -1795,24 +1463,8 @@ categorizations:
       - "property:distribute-source-code"
       - "property:patent-clause"
 
-  - id: "IPTC"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
   # https://spdx.org/licenses/ISC.html
   - id: "ISC"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
-  - id: "ISC-possibility"
-    categories:
-      - "permissive"
-
-  - id: "ISC-style"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
@@ -1839,17 +1491,6 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  - id: "Intel-Binary"
-    categories:
-      - "proprietary-free"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:unchecked"
-
-  - id: "Intel-WLAN"
-    categories:
-      - "irrelevant"
-
   # https://spdx.org/licenses/JPNIC.html
   - id: "JPNIC"
     categories:
@@ -1863,30 +1504,6 @@ categorizations:
       - "permissive"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
-
-  - id: "Keyspan-FW"
-    categories:
-      - "proprietary-free"
-      - "property:unchecked"
-
-  # https://tldp.org/COPYRIGHT.html
-  - id: "LDPL"
-    categories:
-      - "copyleft-file-level"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
-  - id: "LGPL"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  # https://spdx.org/licenses/LGPL-2.0-only.html
-  - id: "LGPL-2.0"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:distribute-source-code"
 
   # https://spdx.org/licenses/LGPL-2.0-only.html
   - id: "LGPL-2.0-only"
@@ -1917,24 +1534,6 @@ categorizations:
   # https://spdx.org/licenses/LGPL-2.0-or-later.html
   # https://spdx.org/licenses/OCaml-LGPL-linking-exception.html
   - id: "LGPL-2.0-or-later WITH OCaml-LGPL-linking-exception"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:AutoConf-or-other-exception"
-
-  # https://spdx.org/licenses/LGPL-2.1-only.html
-  - id: "LGPL-2.1"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/LGPL-2.1-only.html
-  # https://spdx.org/licenses/Linux-syscall-note.html
-  - id: "LGPL-2.1 WITH Linux-syscall-note"
     categories:
       - "copyleft-LGPL"
       - "property:include-in-notice-file"
@@ -2007,16 +1606,6 @@ categorizations:
       - "property:AutoConf-or-other-exception"
 
   # https://spdx.org/licenses/LGPL-3.0-only.html
-  - id: "LGPL-3.0"
-    categories:
-      - "copyleft-LGPL"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:antitivo-clause"
-      - "property:distribute-source-code"
-      - "property:patent-clause"
-
-  # https://spdx.org/licenses/LGPL-3.0-only.html
   - id: "LGPL-3.0-only"
     categories:
       - "copyleft-LGPL"
@@ -2048,10 +1637,6 @@ categorizations:
       - "property:patent-clause"
       - "property:AutoConf-or-other-exception"
 
-  - id: "LGPL-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
-
   # https://spdx.org/licenses/LPL-1.02.html
   - id: "LPL-1.02"
     categories:
@@ -2069,14 +1654,6 @@ categorizations:
       - "include-in-notice-file"
       - "property:distribute-source-code"
 
-  # https://spdx.org/licenses/LPPL-1.0.html
-  - id: "LPPL-1.0-or-later"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:distribute-source-code"
-
   # https://spdx.org/licenses/LPPL-1.2.html
   - id: "LPPL-1.2"
     categories:
@@ -2087,14 +1664,6 @@ categorizations:
 
   # https://spdx.org/licenses/LPPL-1.2.html
   - id: "LPPL-1.2+"
-    categories:
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:distribute-source-code"
-
-  # https://spdx.org/licenses/LPPL-1.2.html
-  - id: "LPPL-1.2-or-later"
     categories:
       - "copyleft-strong"
       - "property:include-in-notice-file"
@@ -3996,14 +3565,6 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  - id: "Linux-syscall-note"
-    categories:
-      - "property:AutoConf-or-other-exception"
-      - "copyleft-strong"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:distribute-source-code"
-
   # https://spdx.org/licenses/MIT.html
   - id: "MIT"
     categories:
@@ -4030,28 +3591,12 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  - id: "MIT-old-style-no-adv"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
   # https://spdx.org/licenses/MIT-open-group.html
   - id: "MIT-open-group"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
-
-  - id: "MIT-possibility"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
-  - id: "MIT-style"
-    categories:
-      - "permissive"
 
   # https://spdx.org/licenses/MITNFA.html
   - id: "MITNFA"
@@ -4060,10 +3605,6 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
       - "property:modification-related-obligations"
-
-  - id: "MPL"
-    categories:
-      - "property:unclear-scanner-finding"
 
   # https://spdx.org/licenses/MPL-1.0.html
   - id: "MPL-1.0"
@@ -4132,23 +3673,11 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  - id: "Microsoft"
-    categories:
-      - "proprietary-free"
-
-  - id: "Microsoft-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
-
   - id: "Minpack"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
-
-  - id: "Motorola"
-    categories:
-      - "commercial"
 
   - id: "NCSA"
     categories:
@@ -4167,10 +3696,6 @@ categorizations:
       - "include-in-notice-file"
       - "property:distribute-source-code"
       - "property:patent-clause"
-
-  - id: "NOT-public-domain"
-    categories:
-      - "irrelevant"
 
   # https://spdx.org/licenses/NPL-1.1.html
   - id: "NPL-1.1"
@@ -4205,42 +3730,11 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  - id: "NewBSD"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
-  - id: "Non-commercial"
-    categories:
-      - "property:unchecked"
-      - "property:non-commercial"
-
-  - id: "Non-profit"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "Not-Free"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "Not-for-sale"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "NotreDame-style"
-    categories:
-      - "permissive"
-
   - id: "Noweb"
     categories:
       - "copyleft-module-level"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
-
-  - id: "Nvidia-EULA-b"
-    categories:
-      - "commercial"
 
   # https://spdx.org/licenses/ODC-By-1.0.html
   - id: "ODC-By-1.0"
@@ -4290,13 +3784,6 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "OLDAP"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
   # https://spdx.org/licenses/OLDAP-2.0.1.html
   - id: "OLDAP-2.0.1"
     categories:
@@ -4310,10 +3797,6 @@ categorizations:
       - "permissive"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
-
-  - id: "OSF-style"
-    categories:
-      - "property:unclear-scanner-finding"
 
   # https://spdx.org/licenses/OSL-2.1.html
   - id: "OSL-2.1"
@@ -4349,18 +3832,6 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  - id: "Patent-ref"
-    categories:
-      - "irrelevant"
-
-  - id: "Perl-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "Permissive-no-warranty"
-    categories:
-      - "permissive"
-
   - id: "Plexus"
     categories:
       - "permissive"
@@ -4372,24 +3843,6 @@ categorizations:
       - "permissive"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
-
-  - id: "Public-domain"
-    categories:
-      - "public-domain"
-
-  - id: "Public-domain-ref"
-    categories:
-      - "public-domain"
-
-  - id: "Public-domainC"
-    categories:
-      - "public-domain"
-
-  - id: "Python"
-    categories:
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "permissive"
 
   # https://spdx.org/licenses/Python-2.0.html
   - id: "Python-2.0"
@@ -4405,20 +3858,6 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
       - "property:mark-modifications"
-
-  # https://www.python.org/download/releases/2.1.1/license/
-  - id: "Python-2.1.1"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "Python-2.2"
-    categories:
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "permissive"
 
   - id: "Qhull"
     categories:
@@ -4441,20 +3880,12 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  - id: "RSA-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
-
   # https://spdx.org/licenses/Rdisc.html
   - id: "Rdisc"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
-
-  - id: "RedHat"
-    categories:
-      - "commercial"
 
   # https://spdx.org/licenses/Ruby.html
   - id: "Ruby"
@@ -4493,47 +3924,11 @@ categorizations:
     categories:
       - "permissive"
 
-  # http://publib.boulder.ibm.com/tividd/td/TWS/SC32-1267-00/en_US/HTML/eqqm1mst68.htm
-  - id: "SSLeay"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:advertising-clause"
-
-  - id: "Same-license-as"
-    categories:
-      - "property:unclear-scanner-finding"
-
   - id: "Saxpath"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
-
-  - id: "See-URL"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "See-doc.OTHER"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "See-file"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "See-file.COPYING"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "See-file.LICENSE"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "See-file.README"
-    categories:
-      - "property:unclear-scanner-finding"
 
   # https://spdx.org/licenses/Spencer-86.html
   - id: "Spencer-86"
@@ -4548,16 +3943,6 @@ categorizations:
       - "permissive"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
-
-  - id: "Sun-RPC"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
-  - id: "Sun-possibility"
-    categories:
-      - "property:unclear-scanner-finding"
 
   - id: "SunPro"
     categories:
@@ -4583,31 +3968,6 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
       - "property:distribute-source-code"
-
-  - id: "U-Mich-style"
-    categories:
-      - "permissive"
-
-  - id: "U-Michigan"
-    categories:
-      - "permissive"
-
-  - id: "USC"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
-  - id: "UnclassifiedLicense"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "Unicode"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
 
   # https://spdx.org/licenses/Unicode-DFS-2015.html
   - id: "Unicode-DFS-2015"
@@ -4658,35 +4018,10 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "W3C-IP"
-    categories:
-      - "property:unclear-scanner-finding"
-
-  - id: "W3C-possibility"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
-  # https://spdx.org/licenses/W3C.html
-  - id: "W3C-style"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
   # https://spdx.org/licenses/WTFPL.html
   - id: "WTFPL"
     categories:
       - "public-domain"
-
-  # https://scancode-licensedb.aboutcode.org/wordnet.html
-  - id: "WordNet-3.0"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
 
   # https://spdx.org/licenses/X11.html
   - id: "X11"
@@ -4701,14 +4036,6 @@ categorizations:
       - "permissive"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
-
-  - id: "X11-possibility"
-    categories:
-      - "permissive"
-
-  - id: "X11-style"
-    categories:
-      - "permissive"
 
   # https://spdx.org/licenses/XFree86-1.1.html
   - id: "XFree86-1.1"
@@ -4771,34 +4098,9 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  - id: "Zlib-possibility"
-    categories:
-      - "permissive"
-
-  # https://spdx.org/licenses/Zlib.html
-  - id: "Zlib-style"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
   - id: "blessing"
     categories:
       - "public-domain"
-
-  # Duplicate of the previous classification due to tooling requirements.
-  - id: "bzip2"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
-  # https://spdx.org/licenses/bzip2-1.0.5.html
-  - id: "bzip2-1.0.5"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
 
   # https://spdx.org/licenses/bzip2-1.0.5.html
   - id: "bzip2-1.0.6"
@@ -4823,25 +4125,6 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  - id: "eCos-2.0"
-    categories:
-      - "copyleft-file-level"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "property:distribute-source-code"
-      - "property:unchecked"
-
-  # https://scancode-licensedb.aboutcode.org/fsf-unlimited-no-warranty.html
-  - id: "fsf-unlimited-no-warranty"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
-  - id: "gary-s-brown"
-    categories:
-      - "permissive"
-
   # https://spdx.org/licenses/libselinux-1.0.html
   - id: "libselinux-1.0"
     categories:
@@ -4859,46 +4142,12 @@ categorizations:
       - "property:include-in-notice-file"
       - "include-in-notice-file"
 
-  - id: "redistribution-only-license"
-    categories:
-      - "proprietary-free"
-
-  - id: "scancode-mit-old-style"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
   # https://spdx.org/licenses/snprintf.html
   - id: "snprintf"
     categories:
       - "permissive"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
-
-  - id: "st-mcd-2.0"
-    categories:
-      - "free-restricted"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
-  - id: "tso-license"
-    categories:
-      - "permissive"
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-
-  - id: "ubuntu-font-1.0"
-    categories:
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "free-restricted"
-
-  - id: "verbatim-distribution-license"
-    categories:
-      - "property:include-in-notice-file"
-      - "include-in-notice-file"
-      - "permissive"
 
   # https://spdx.org/licenses/xpp.html
   - id: "xpp"

--- a/scripts/check-license-classifications.main.kts
+++ b/scripts/check-license-classifications.main.kts
@@ -24,7 +24,7 @@ val licenseClassifications = runCatching {
 }
 
 val (validLicenses, invalidLicenses) = licenseClassifications.categoriesByLicense.keys.partition {
-    it.isValid(Strictness.ALLOW_ANY)
+    it.isValid(Strictness.ALLOW_LICENSEREF_EXCEPTIONS)
 }
 
 if (invalidLicenses.isNotEmpty()) {


### PR DESCRIPTION
Clean up `license-classifications.yml` according to guidelines from license classifications workshop. Also turn on a tight check of the licenses when doing PRs.