### PR TITLE
Removed property:advertising-clause from XPP license, due to updated …

### DIFF
--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -4321,7 +4321,6 @@ categorizations:
       - "permissive"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
-      - "property:advertising-clause"
 
   # https://spdx.org/licenses/zlib-acknowledgement.html
   - id: "zlib-acknowledgement"


### PR DESCRIPTION
…policy with respect to Apache-1.1 type of notice obligations.