### PR TITLE
Add mark-modifications to PSF 2.0 and Python-2.0, clause 3

### DIFF
--- a/license-classifications.yml
+++ b/license-classifications.yml
@@ -4078,6 +4078,7 @@ categorizations:
       - "permissive"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
+      - "property:mark-modifications"
 
   - id: "Plexus"
     categories:
@@ -4097,6 +4098,7 @@ categorizations:
       - "permissive"
       - "property:include-in-notice-file"
       - "include-in-notice-file"
+      - "property:mark-modifications"
 
   # https://www.python.org/download/releases/2.0.1/license/
   - id: "Python-2.0.1"


### PR DESCRIPTION
Noted missing mark-modifications property, see clause 3: 

at https://spdx.org/licenses/Python-2.0.html

`3. In the event Licensee prepares a derivative work that is based on or incorporates Python or any part thereof, and wants to make the derivative work available to others as provided herein, then Licensee hereby agrees to include in any such work a brief summary of the changes made to Python. `

and at https://spdx.org/licenses/PSF-2.0.html

`3. In the event Licensee prepares a derivative work that is based on or incorporates Python or any part thereof, and wants to make the derivative work available to others as provided herein, then Licensee hereby agrees to include in any such work a brief summary of the changes made to Python.`
